### PR TITLE
feat: Tag 컴포넌트 구현 

### DIFF
--- a/src/shared/components/tag/Tag.stories.tsx
+++ b/src/shared/components/tag/Tag.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import Tag from "./Tag"
+
+const meta = {
+  title: "Components/Tag",
+  component: Tag,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    label: {
+      control: "text",
+    },
+    size: {
+      control: "radio",
+      options: ["sm", "md"],
+    },
+    variant: {
+      control: "radio",
+      options: ["outlined", "selected", "soft", "subtle"],
+    },
+    onClick: {
+      action: "clicked",
+    },
+  },
+} satisfies Meta<typeof Tag>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    label: "산뜻한",
+    size: "sm",
+    variant: "outlined",
+  },
+}
+
+export const Selected: Story = {
+  args: {
+    label: "생기 있는",
+    size: "sm",
+    variant: "selected",
+  },
+}
+
+export const Soft: Story = {
+  args: {
+    label: "따뜻한",
+    size: "sm",
+    variant: "soft",
+  },
+}
+
+export const Subtle: Story = {
+  args: {
+    label: "베르가못",
+    size: "sm",
+    variant: "subtle",
+  },
+}

--- a/src/shared/components/tag/Tag.tsx
+++ b/src/shared/components/tag/Tag.tsx
@@ -1,0 +1,56 @@
+import { cva } from "class-variance-authority"
+import clsx from "clsx"
+
+type TagVariant = "outlined" | "selected" | "soft" | "subtle"
+type TagSize = "sm" | "md"
+
+type TagProps = {
+  label: string
+  size?: TagSize
+  variant?: TagVariant
+  onClick?: () => void
+}
+
+const tagVariants = cva(
+  "inline-flex items-center justify-center rounded-full transition-colors",
+  {
+    variants: {
+      size: {
+        sm: "text-sm py-sm px-md",
+        md: "text-md py-xs px-sm",
+      },
+      variant: {
+        outlined: "cursor-pointer border border-border text-text-sub bg-gray-0",
+        selected: "cursor-pointer bg-button text-text-button",
+        soft: "cursor-default bg-surface-container text-text-highlight",
+        subtle:
+          "cursor-default border border-border bg-surface-default text-text-sub",
+      },
+    },
+    defaultVariants: {
+      size: "sm",
+      variant: "outlined",
+    },
+  }
+)
+
+const Tag = ({ label, size, variant, onClick }: TagProps) => {
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onClick}
+        className={clsx(
+          tagVariants({
+            size,
+            variant,
+          })
+        )}
+      >
+        {label}
+      </button>
+    </>
+  )
+}
+
+export default Tag

--- a/src/shared/components/tag/index.tsx
+++ b/src/shared/components/tag/index.tsx
@@ -1,0 +1,1 @@
+export { default as Tag } from "./Tag"


### PR DESCRIPTION
## 📌 작업 내용

- Tag 컴포넌트 기본 구조 구현
- `outlined`, `selected`, `soft`, `subtle` variant 추가
- `sm`, `md` size variant 추가
- cva를 사용해 스타일 분기 처리
- 기본 variant와 size 설정
- Storybook 기본 스토리 추가

## 🔗 관련 이슈

- closes #37 

## 📸 스크린샷 (선택)
<img width="1095" height="681" alt="image" src="https://github.com/user-attachments/assets/f95f73f7-fa95-47d3-9735-a333e7db6461" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
