### PR TITLE
feat: History 카드 컴포넌트 추가

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,7 @@ package.json
 package-lock.json
 .husky
 .github
+.vscode
 tsconfig.json
 tsconfig.app.json
 tsconfig.node.json

--- a/src/features/my-page/components/history-card/HistoryCard.stories.tsx
+++ b/src/features/my-page/components/history-card/HistoryCard.stories.tsx
@@ -46,7 +46,7 @@ export const Default: Story = {
 
 export const WithoutImage: Story = {
   args: {
-    imageSrc: undefined, // 👈 중요
+    imageSrc: undefined,
     title: "Blossom Dream",
     badgeText: "챗봇 추천",
     tags: ["체리 블라썸", "머스크", "바닐라"],

--- a/src/features/my-page/components/history-card/HistoryCard.stories.tsx
+++ b/src/features/my-page/components/history-card/HistoryCard.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import HistoryCard from "./HistoryCard"
+
+const meta: Meta<typeof HistoryCard> = {
+  title: "Common/HistoryCard",
+  component: HistoryCard,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `
+HistoryCard는 추천 히스토리 정보를 카드 형태로 보여주는 컴포넌트입니다.
+
+### 특징
+- 이미지가 없을 경우 Empty 컴포넌트를 fallback으로 사용합니다
+- 태그 리스트와 날짜 정보를 함께 표시합니다
+
+### 예시
+\`\`\`tsx
+<HistoryCard
+  title="Blossom Dream"
+  tags={["체리 블라썸", "머스크", "바닐라"]}
+  date="2026.04.06"
+/>
+\`\`\`
+        `,
+      },
+    },
+  },
+  tags: ["autodocs"],
+}
+
+export default meta
+type Story = StoryObj<typeof HistoryCard>
+
+export const Default: Story = {
+  args: {
+    imageSrc:
+      "https://images.unsplash.com/photo-1591925463023-1ca6b0636780?auto=format&fit=crop&w=200&q=80",
+    title: "Blossom Dream",
+    badgeText: "챗봇 추천",
+    tags: ["체리 블라썸", "머스크", "바닐라"],
+    date: "2026.04.06",
+  },
+}
+
+export const WithoutImage: Story = {
+  args: {
+    imageSrc: undefined, // 👈 중요
+    title: "Blossom Dream",
+    badgeText: "챗봇 추천",
+    tags: ["체리 블라썸", "머스크", "바닐라"],
+    date: "2026.04.06",
+  },
+}

--- a/src/features/my-page/components/history-card/HistoryCard.tsx
+++ b/src/features/my-page/components/history-card/HistoryCard.tsx
@@ -1,0 +1,83 @@
+import { CalendarDays, ChevronRight } from "lucide-react"
+import { useState } from "react"
+
+import type { HistoryCardProps } from "@/features/my-page/types"
+import { cn } from "@/lib/utils"
+import { Empty } from "@/shared/components"
+
+const HistoryCard = ({
+  imageSrc,
+  imageAlt = "history image",
+  title,
+  badgeText = "챗봇 추천",
+  tags = [],
+  date,
+  onClick,
+  className,
+}: HistoryCardProps) => {
+  const [isError, setIsError] = useState(false)
+
+  return (
+    // 추후 공통 Button 컴포넌트로 대체 예정
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex w-container-md items-center gap-4 rounded-md border border-primary bg-white px-4 py-3 text-left shadow-md transition-all",
+        "hover:bg-gray-5 hover:shadow-lg",
+        className
+      )}
+    >
+      <div className="flex size-25 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-disabled">
+        {imageSrc && !isError ? (
+          <img
+            src={imageSrc}
+            alt={imageAlt}
+            className="block h-full w-full object-cover"
+            onError={() => setIsError(true)}
+          />
+        ) : (
+          <Empty type="image" size="sm" className="rounded-lg" />
+        )}
+      </div>
+
+      <div className="flex-1">
+        <div className="flex items-center gap-2">
+          <h3 className="min-w-0 truncate text-lg font-bold leading-none text-text-primary">
+            {title}
+          </h3>
+
+          {badgeText && (
+            <span className="inline-flex h-6 shrink-0 items-center rounded-full bg-badge px-2 text-sm font-semibold text-text-description">
+              {badgeText}
+            </span>
+          )}
+        </div>
+
+        {!!tags.length && (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex h-10 items-center rounded-md border border-border px-5 pt-1 text-md text-text-sub"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex shrink-0 flex-col items-end justify-between self-stretch">
+        <ChevronRight size={18} className="text-text-sub" strokeWidth={2} />
+
+        <div className="flex items-center gap-1 text-sm text-text-sub">
+          <CalendarDays size={12} strokeWidth={2} />
+          <span className="pt-1">{date}</span>
+        </div>
+      </div>
+    </button>
+  )
+}
+
+export default HistoryCard

--- a/src/features/my-page/types/analysis.ts
+++ b/src/features/my-page/types/analysis.ts
@@ -1,0 +1,21 @@
+// API 명세서에 맞는 타입 정의
+export type GetAnalysesParams = {
+  page: number
+  size: number
+}
+
+export type Analysis = {
+  analysis_id: number
+  thumbnail_url: string | null
+  recommended_scent: string
+  created_at: string
+}
+
+export type GetAnalysesResponse = {
+  data: {
+    total_count: number
+    total_pages: number
+    current_page: number
+    results: Analysis[]
+  }
+}

--- a/src/features/my-page/types/history.ts
+++ b/src/features/my-page/types/history.ts
@@ -1,0 +1,20 @@
+export type HistoryCardProps = {
+  imageSrc?: string
+  imageAlt?: string
+  title: string
+  badgeText?: string
+  tags?: string[]
+  date: string
+  onClick?: () => void
+  className?: string
+}
+
+// 추후 렌더링 단계에서 사용
+export type HistoryCardItem = {
+  id: number
+  imageSrc?: string
+  title: string
+  badgeText?: string
+  tags?: string[]
+  date: string
+}

--- a/src/features/my-page/types/index.ts
+++ b/src/features/my-page/types/index.ts
@@ -1,0 +1,2 @@
+export * from "./analysis"
+export * from "./history"

--- a/src/index.css
+++ b/src/index.css
@@ -83,6 +83,7 @@
 
   /* Component */
   --color-card: var(--white);
+  --color-badge: var(--color-green-5);
   --color-tag: var(--color-green-10);
   --color-button: var(--color-green-40);
   --color-chatbot: var(--color-green-50);
@@ -166,6 +167,7 @@
   --color-primary-disabled: var(--color-primary-disabled);
 
   --color-card: var(--color-card);
+  --color-badge: var(--color-badge);
   --color-tag: var(--color-tag);
   --color-button: var(--color-button);
   --color-chatbot: var(--color-chatbot);
@@ -213,6 +215,16 @@
   --text-lg: var(--text-lg);
   --text-xl: var(--text-xl);
   --text-2xl: var(--text-2xl);
+
+  /* container sizes */
+  --size-container-sm: var(--size-container-sm);
+  --size-container-md: var(--size-container-md);
+  --size-container-lg: var(--size-container-lg);
+  --size-container-xl: var(--size-container-xl);
+  --width-container-sm: var(--size-container-sm);
+  --width-container-md: var(--size-container-md);
+  --width-container-lg: var(--size-container-lg);
+  --width-container-xl: var(--size-container-xl);
 
   /* radius */
   --radius-sm: var(--radius-sm);

--- a/src/shared/components/empty/Empty.tsx
+++ b/src/shared/components/empty/Empty.tsx
@@ -48,7 +48,7 @@ const Empty = ({
           sizeStyle[type][size],
           isAvatar
             ? "rounded-full bg-white shadow-md"
-            : "rounded-lg bg-disabled",
+            : "rounded-lg bg-primary-disabled",
           className
         )}
       >


### PR DESCRIPTION
## 📌 작업 내용

- history 카드 컴포넌트를 추가했습니다.
- API 명세서를 고려하여 type을 분리해두었는데, analysis.ts는 현재 사용하지 않습니다. 추후 수정 가능성이 있습니다.

## 🔗 관련 이슈

- closes #35 

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
