### PR TITLE
feat: 공통 컴포넌트 Input 제작

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -70,7 +70,6 @@
 
   /* STATUS PALETTE */
   --answer-active: #04c730;
-  --toast-error: #ec0037;
 
   /* =====================================================
    SEMANTIC TOKENS (역할 기반)
@@ -103,9 +102,11 @@
   /* border */
   --color-border: var(--color-gray-20);
   --color-border-primary: var(--color-primary);
+  --color-border-error:  
 
-  /* Surface */
-  --color-surface-default: var(--color-bg-default);
+  /* Surface */ --color-surface-default: var(
+      --color-bg-default
+    );
   --color-surface-container: var(--color-bg-container);
 
   /* Toast */

--- a/src/index.css
+++ b/src/index.css
@@ -102,11 +102,8 @@
   /* border */
   --color-border: var(--color-gray-20);
   --color-border-primary: var(--color-primary);
-  --color-border-error:  
-
-  /* Surface */ --color-surface-default: var(
-      --color-bg-default
-    );
+  --color-border-error: var(--) /* Surface */
+    --color-surface-default: var(--color-bg-default);
   --color-surface-container: var(--color-bg-container);
 
   /* Toast */

--- a/src/index.css
+++ b/src/index.css
@@ -70,6 +70,7 @@
 
   /* STATUS PALETTE */
   --answer-active: #04c730;
+  --toast-error: #ec0037;
 
   /* =====================================================
    SEMANTIC TOKENS (역할 기반)
@@ -102,8 +103,9 @@
   /* border */
   --color-border: var(--color-gray-20);
   --color-border-primary: var(--color-primary);
-  --color-border-error: var(--) /* Surface */
-    --color-surface-default: var(--color-bg-default);
+
+  /* Surface */
+  --color-surface-default: var(--color-bg-default);
   --color-surface-container: var(--color-bg-container);
 
   /* Toast */

--- a/src/shared/components/inputs/Input/Input.stories.tsx
+++ b/src/shared/components/inputs/Input/Input.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import Input from "./Input"
 
-// const ChildDiv = () => {
-//   return <div className="size-4 bg-amber-300" />
-// }
+const ChildDiv = () => {
+  return <div className="size-4 bg-amber-300" />
+}
 
 const meta = {
   title: "Shared/Inputs/Input",
@@ -66,5 +66,12 @@ export const Disabled: Story = {
   args: {
     disabled: true,
     value: "Disabled input",
+  },
+}
+
+export const WithTrailingChild: Story = {
+  args: {
+    placeholder: "With trailing child...",
+    trailingChild: <ChildDiv />,
   },
 }

--- a/src/shared/components/inputs/Input/Input.stories.tsx
+++ b/src/shared/components/inputs/Input/Input.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import Input from "./Input"
+
+const meta = {
+  title: "Shared/Inputs/Input",
+  component: Input,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    status: {
+      control: "select",
+      options: ["none", "success", "error"],
+      description: "Input status",
+    },
+    placeholder: {
+      control: "text",
+      description: "Placeholder text",
+    },
+    value: {
+      control: "text",
+      description: "Input value",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Whether input is disabled",
+    },
+  },
+} satisfies Meta<typeof Input>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    placeholder: "Enter text...",
+  },
+}
+
+export const WithValue: Story = {
+  args: {
+    value: "Sample input text",
+  },
+}
+
+export const Success: Story = {
+  args: {
+    status: "success",
+    value: "Valid input",
+  },
+}
+
+export const WithError: Story = {
+  args: {
+    status: "error",
+    value: "Invalid input",
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    value: "Disabled input",
+  },
+}

--- a/src/shared/components/inputs/Input/Input.stories.tsx
+++ b/src/shared/components/inputs/Input/Input.stories.tsx
@@ -1,6 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import Input from "./Input"
 
+// const ChildDiv = () => {
+//   return <div className="size-4 bg-amber-300" />
+// }
+
 const meta = {
   title: "Shared/Inputs/Input",
   component: Input,

--- a/src/shared/components/inputs/Input/Input.tsx
+++ b/src/shared/components/inputs/Input/Input.tsx
@@ -1,0 +1,5 @@
+const Input = () => {
+  return <div></div>
+}
+
+export default Input

--- a/src/shared/components/inputs/Input/Input.tsx
+++ b/src/shared/components/inputs/Input/Input.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from "react"
 import { Hstack } from "../../layouts"
 
 const inputVariants = cva(
-  "rounded-sm transition items-center outline flex-1 bg-card text-text-primary",
+  "rounded-sm transition items-center outline flex-1 bg-card text-text-primary disabled:text-text-disabled",
   {
     variants: {
       status: {
@@ -27,11 +27,15 @@ const Input = ({
   trailingChild,
   ...props
 }: InputProps & WithInputProps) => {
-  const { className, ...rest } = props
+  const { className, disabled, ...rest } = props
 
   return (
     <Hstack>
-      <Input {...rest} className={clsx(inputVariants({ status }), className)} />
+      <Input
+        {...rest}
+        disabled={disabled}
+        className={clsx(inputVariants({ status }), className)}
+      />
       {trailingChild}
     </Hstack>
   )

--- a/src/shared/components/inputs/Input/Input.tsx
+++ b/src/shared/components/inputs/Input/Input.tsx
@@ -1,5 +1,40 @@
-const Input = () => {
-  return <div></div>
+import type { InputProps } from "@/shared/types"
+import type { None } from "@/shared/types/commonPropsTypes/commonPropsTypes"
+import { cva } from "class-variance-authority"
+import clsx from "clsx"
+import type { ReactNode } from "react"
+import { Hstack } from "../../layouts"
+
+const inputVariants = cva(
+  "rounded-sm transition items-center outline flex-1 bg-card text-text-primary",
+  {
+    variants: {
+      status: {
+        none: "",
+        success: "outline-border-primary",
+        error: "outline-border-toast-error",
+      },
+    },
+  }
+)
+
+type WithInputProps = {
+  status?: None | "success" | "error"
+  trailingChild?: ReactNode
+}
+const Input = ({
+  status = "none",
+  trailingChild,
+  ...props
+}: InputProps & WithInputProps) => {
+  const { className, ...rest } = props
+
+  return (
+    <Hstack>
+      <Input {...rest} className={clsx(inputVariants({ status }), className)} />
+      {trailingChild}
+    </Hstack>
+  )
 }
 
 export default Input

--- a/src/shared/components/inputs/Input/Input.tsx
+++ b/src/shared/components/inputs/Input/Input.tsx
@@ -7,11 +7,11 @@ import type { ReactNode } from "react"
 import { Hstack } from "../../layouts"
 
 const inputVariants = cva(
-  "p-lg rounded-sm transition items-center outline bg-card text-text-primary disabled:text-text-disabled",
+  "p-lg rounded-sm transition items-center outline bg-card text-text-primary disabled:text-text-disabled focus-within:shadow-box",
   {
     variants: {
       status: {
-        none: "outline-border focus-within:outline-border-text-primary focus-within:outline-2",
+        none: "outline-border focus-within:outline-text-primary focus-within:outline-2",
         success: "outline-border-primary focus-within:outline-2",
         error: "outline-(--toast-error-color) focus-within:outline-2",
       },

--- a/src/shared/components/inputs/Input/Input.tsx
+++ b/src/shared/components/inputs/Input/Input.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from "react"
 import { Hstack } from "../../layouts"
 
 const inputVariants = cva(
-  "p-lg rounded-sm transition items-center outline flex-1 bg-card text-text-primary disabled:text-text-disabled",
+  "p-lg rounded-sm transition items-center outline bg-card text-text-primary disabled:text-text-disabled",
   {
     variants: {
       status: {
@@ -32,11 +32,11 @@ const Input = ({
 
   console.log("---- rerendered")
   return (
-    <Hstack>
+    <Hstack className={clsx(inputVariants({ status }), className)}>
       <input
         {...rest}
         disabled={disabled}
-        className={clsx(inputVariants({ status }), className)}
+        className="flex-1 border-0 px-3 py-2 outline-0"
       />
       {trailingChild}
     </Hstack>

--- a/src/shared/components/inputs/Input/Input.tsx
+++ b/src/shared/components/inputs/Input/Input.tsx
@@ -7,17 +7,13 @@ import type { ReactNode } from "react"
 import { Hstack } from "../../layouts"
 
 const inputVariants = cva(
-  // "p-lg rounded-sm transition items-center outline flex-1 bg-card text-text-primary disabled:text-text-disabled",
   "p-lg rounded-sm transition items-center outline flex-1 bg-card text-text-primary disabled:text-text-disabled",
   {
     variants: {
       status: {
-        none: "",
-        success: "",
-        error: "",
-        // none: "outline-border",
-        // success: "outline-border-primary",
-        // error: "outline-toast-error-color",
+        none: "outline-border",
+        success: "outline-border-primary",
+        error: "outline-(--toast-error-color)",
       },
     },
   }
@@ -40,11 +36,7 @@ const Input = ({
       <input
         {...rest}
         disabled={disabled}
-        className={clsx(
-          inputVariants({ status }),
-          className,
-          "bg-(--toast-error-color)"
-        )}
+        className={clsx(inputVariants({ status }), className)}
       />
       {trailingChild}
     </Hstack>

--- a/src/shared/components/inputs/Input/Input.tsx
+++ b/src/shared/components/inputs/Input/Input.tsx
@@ -2,17 +2,22 @@ import type { InputProps } from "@/shared/types"
 import type { None } from "@/shared/types/commonPropsTypes/commonPropsTypes"
 import { cva } from "class-variance-authority"
 import clsx from "clsx"
+// import type { ReactNode } from "react"
 import type { ReactNode } from "react"
 import { Hstack } from "../../layouts"
 
 const inputVariants = cva(
-  "rounded-sm transition items-center outline flex-1 bg-card text-text-primary disabled:text-text-disabled",
+  // "p-lg rounded-sm transition items-center outline flex-1 bg-card text-text-primary disabled:text-text-disabled",
+  "p-lg rounded-sm transition items-center outline flex-1 bg-card text-text-primary disabled:text-text-disabled",
   {
     variants: {
       status: {
         none: "",
-        success: "outline-border-primary",
-        error: "outline-border-toast-error",
+        success: "",
+        error: "",
+        // none: "outline-border",
+        // success: "outline-border-primary",
+        // error: "outline-toast-error-color",
       },
     },
   }
@@ -29,12 +34,17 @@ const Input = ({
 }: InputProps & WithInputProps) => {
   const { className, disabled, ...rest } = props
 
+  console.log("---- rerendered")
   return (
     <Hstack>
-      <Input
+      <input
         {...rest}
         disabled={disabled}
-        className={clsx(inputVariants({ status }), className)}
+        className={clsx(
+          inputVariants({ status }),
+          className,
+          "bg-(--toast-error-color)"
+        )}
       />
       {trailingChild}
     </Hstack>

--- a/src/shared/components/inputs/Input/Input.tsx
+++ b/src/shared/components/inputs/Input/Input.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from "react"
 import { Hstack } from "../../layouts"
 
 const inputVariants = cva(
-  "p-lg rounded-sm transition items-center outline bg-card text-text-primary disabled:text-text-disabled focus-within:shadow-box",
+  "rounded-sm transition items-center outline bg-card text-text-primary disabled:text-text-disabled focus-within:shadow-box",
   {
     variants: {
       status: {
@@ -36,7 +36,7 @@ const Input = ({
       <input
         {...rest}
         disabled={disabled}
-        className="flex-1 border-0 px-3 py-2 outline-0"
+        className="flex-1 border-0 py-md px-lg outline-0"
       />
       {trailingChild}
     </Hstack>

--- a/src/shared/components/inputs/Input/Input.tsx
+++ b/src/shared/components/inputs/Input/Input.tsx
@@ -11,9 +11,9 @@ const inputVariants = cva(
   {
     variants: {
       status: {
-        none: "outline-border",
-        success: "outline-border-primary",
-        error: "outline-(--toast-error-color)",
+        none: "outline-border focus-within:outline-border-text-primary focus-within:outline-2",
+        success: "outline-border-primary focus-within:outline-2",
+        error: "outline-(--toast-error-color) focus-within:outline-2",
       },
     },
   }

--- a/src/shared/components/inputs/index.ts
+++ b/src/shared/components/inputs/index.ts
@@ -1,1 +1,2 @@
 export { default as Button } from "./Button/Button"
+export { default as Input } from "./Input/Input.tsx"


### PR DESCRIPTION
## 📌 작업 내용

- 인풋 컴포넌트 제작
- 스토리북 생성

## 🔗 관련 이슈

- closes #40

## 📸 스크린샷 (선택)

<img width="1038" height="315" alt="image" src="https://github.com/user-attachments/assets/a6d96150-c31b-466b-b5e4-0acff7991510" />

figma 상에서는 텍스트 주위로 패딩이 16px 정도 되어서 p-lg를 썼습니다만, 다소 광활해보이는 것 같기도 합니다.
두 분께서 어떻게 생각하시는지 말씀해주시면 수정하겠습니다

<img width="1050" height="293" alt="image" src="https://github.com/user-attachments/assets/56b62993-5a8c-4692-8a81-1403a70055e2" />

끝에 추가적 버튼, 아이콘을 넣는 부분은 맨 아래로 내리셔서 확인하실 수 있습니다

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
