### PR TITLE
feat: State Bar 컴포넌트

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -226,6 +226,11 @@
   --width-container-lg: var(--size-container-lg);
   --width-container-xl: var(--size-container-xl);
 
+  /* button sizes */
+  --size-button-sm: var(--size-button-sm);
+  --size-button-md: var(--size-button-md);
+  --size-button-lg: var(--size-button-lg);
+
   /* radius */
   --radius-sm: var(--radius-sm);
   --radius-md: var(--radius-md);

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -1,3 +1,4 @@
 export { default as Empty } from "./empty/Empty"
 export * from "./inputs"
 export * from "./layouts"
+export { default as StateBar } from "./state-bar/StateBar"

--- a/src/shared/components/state-bar/StateBar.stories.tsx
+++ b/src/shared/components/state-bar/StateBar.stories.tsx
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import StateBar from "./StateBar"
+
+const items = [
+  {
+    label: "상쾌함",
+    value: 21,
+    leftText: "은은한",
+    rightText: "선명한",
+  },
+  {
+    label: "온기",
+    value: 68,
+    leftText: "차가운",
+    rightText: "따뜻한",
+  },
+  {
+    label: "부드러움",
+    value: 48,
+    leftText: "날카로운",
+    rightText: "부드러운",
+  },
+  {
+    label: "깊이감",
+    value: 82,
+    leftText: "가벼운",
+    rightText: "깊이 있는",
+  },
+  {
+    label: "달콤함",
+    value: 78,
+    leftText: "담백한",
+    rightText: "달콤한",
+  },
+]
+
+const meta = {
+  title: "common/StateBar",
+  component: StateBar,
+  tags: ["autodocs"],
+  args: {
+    label: "상쾌함",
+    value: 21,
+    leftText: "은은한",
+    rightText: "선명한",
+  },
+  argTypes: {
+    value: {
+      control: { type: "range", min: 0, max: 100, step: 1 },
+    },
+    height: {
+      control: { type: "number", min: 1, step: 1 },
+    },
+  },
+} satisfies Meta<typeof StateBar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithCustomHeight: Story = {
+  args: {
+    label: "",
+    value: 76,
+    leftText: "은은한",
+    rightText: "강렬한",
+    height: 10,
+  },
+  render: (args) => (
+    <div className="w-full rounded-lg border border-border bg-white flex grid-cols-3 w-full items-center gap-sm p-md">
+      <div className="">
+        <p className="text-text-primary text-md font-bold">Overall Intensity</p>
+        <p className="text-text-sub text-sm">향기의 지속력</p>
+      </div>
+      <div className="w-full">
+        <StateBar {...args} />
+      </div>
+      <div className="flex h-full items-center justify-center p-sm">
+        <div className="flex items-center justify-center size-button-lg rounded-full bg-badge text-text-primary font-bold">
+          76
+        </div>
+      </div>
+    </div>
+  ),
+}
+
+export const TwoColumnLayout: Story = {
+  render: () => (
+    <div className="w-full rounded-lg border border-border bg-white p-lg">
+      <div className="grid grid-cols-2 gap-lg">
+        {items.map((item) => (
+          <StateBar
+            key={item.label}
+            label={item.label}
+            value={item.value}
+            leftText={item.leftText}
+            rightText={item.rightText}
+          />
+        ))}
+      </div>
+    </div>
+  ),
+}
+
+export const VerticalLayout: Story = {
+  render: () => (
+    <div className="w-full rounded-lg border border-border bg-white p-lg">
+      <div className="mb-md text-base font-semibold text-text-primary">
+        SCENT PROFILE
+      </div>
+
+      <div className="flex flex-col gap-md">
+        {items.map((item) => (
+          <StateBar
+            key={item.label}
+            label={item.label}
+            value={item.value}
+            leftText={item.leftText}
+            rightText={item.rightText}
+          />
+        ))}
+      </div>
+    </div>
+  ),
+}

--- a/src/shared/components/state-bar/StateBar.tsx
+++ b/src/shared/components/state-bar/StateBar.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@/lib/utils"
+
 type StateBarProps = {
   label?: string
   value: number
@@ -20,7 +22,10 @@ export default function StateBar({
 
   return (
     <div
-      className={`flex w-full min-w-0 basis-full flex-col self-stretch ${className ?? ""}`}
+      className={cn(
+        "flex w-full min-w-0 basis-full flex-col self-stretch",
+        className
+      )}
     >
       <div className="mb-xs flex w-full min-w-0 items-center justify-between gap-sm">
         <span className="truncate text-sm font-semibold text-text-primary">

--- a/src/shared/components/state-bar/StateBar.tsx
+++ b/src/shared/components/state-bar/StateBar.tsx
@@ -1,0 +1,58 @@
+type StateBarProps = {
+  label?: string
+  value: number
+  leftText?: string
+  rightText?: string
+  className?: string
+  height?: number
+}
+
+export default function StateBar({
+  label,
+  value,
+  leftText,
+  rightText,
+  className,
+  height = 5,
+}: StateBarProps) {
+  const safeValue = Math.max(0, Math.min(100, value))
+  const barHeight = Number.isFinite(height) ? height : 5
+
+  return (
+    <div
+      className={`flex w-full min-w-0 basis-full flex-col self-stretch ${className ?? ""}`}
+    >
+      <div className="mb-xs flex w-full min-w-0 items-center justify-between gap-sm">
+        <span className="truncate text-sm font-semibold text-text-primary">
+          {label}
+        </span>
+        <span className="shrink-0 text-sm font-semibold text-text-primary">
+          {safeValue}%
+        </span>
+      </div>
+
+      <div className="w-full">
+        <div
+          className="overflow-hidden rounded-full bg-primary-disabled border border-border"
+          style={{
+            height: barHeight,
+          }}
+        >
+          <div
+            className="h-full rounded-full bg-primary transition-all"
+            style={{
+              width: `${safeValue}%`,
+            }}
+          />
+        </div>
+      </div>
+
+      {(leftText || rightText) && (
+        <div className="mt-xs flex w-full min-w-0 items-center justify-between gap-sm text-sm text-text-sub">
+          <span className="truncate">{leftText}</span>
+          <span className="truncate">{rightText}</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/shared/data/scent-profile/scent-profile.ts
+++ b/src/shared/data/scent-profile/scent-profile.ts
@@ -1,0 +1,41 @@
+type ProfileItem = {
+  label: string
+  value: number
+  leftText?: string
+  rightText?: string
+}
+
+const scentProfile: ProfileItem[] = [
+  {
+    label: "상쾌함",
+    value: 21,
+    leftText: "은은한",
+    rightText: "선명한",
+  },
+  {
+    label: "온기",
+    value: 68,
+    leftText: "차가운",
+    rightText: "따뜻한",
+  },
+  {
+    label: "부드러움",
+    value: 48,
+    leftText: "날카로운",
+    rightText: "부드러운",
+  },
+  {
+    label: "깊이감",
+    value: 82,
+    leftText: "가벼운",
+    rightText: "깊이 있는",
+  },
+  {
+    label: "달콤함",
+    value: 78,
+    leftText: "담백한",
+    rightText: "달콤한",
+  },
+]
+
+export default scentProfile


### PR DESCRIPTION
## 📌 작업 내용

- State bar 컴포넌트를 제작했습니다.
- height를 props로 받고 있어 화면 크기에 맞게 조절할 수 있습니다.

### 참고 사항
- scent profile 파일은 추후 mock 파일 제작할 때 필요할 것 같아서 미리 넣어뒀습니다. 지금은 사용하지 않습니다.

## 🔗 관련 이슈

- closes #47 

## 📸 스크린샷 (선택)
<img width="585" height="289" alt="image" src="https://github.com/user-attachments/assets/a148349c-fca5-4f44-8f97-106dc3e0c3b6" />
<img width="594" height="701" alt="image" src="https://github.com/user-attachments/assets/bd51ce4c-18e6-4179-bc45-50a1283da58a" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
