### PR TITLE
feat: ArchiveCard 구현

### DIFF
--- a/src/shared/components/archive-card/ArchiveCard.stories.tsx
+++ b/src/shared/components/archive-card/ArchiveCard.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import ArchiveCard from "./ArchiveCard"
+
+const meta = {
+  title: "Components/Card/ArchiveCard",
+  component: ArchiveCard,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-60 box-sizing: border-box">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ["autodocs"],
+  argTypes: {
+    imageSrc: {
+      control: "text",
+    },
+    imageAlt: {
+      control: "text",
+    },
+    tags: {
+      control: "object",
+    },
+    title: {
+      control: "text",
+    },
+    description: {
+      control: "text",
+    },
+  },
+} satisfies Meta<typeof ArchiveCard>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    imageSrc:
+      "https://images.unsplash.com/photo-1515377905703-c4788e51af15?auto=format&fit=crop&w=800&q=80",
+    imageAlt: "우디한 무드의 향기 이미지",
+    tags: ["Woody", "Warm", "Calm"],
+    title: "Serene Woods",
+    description:
+      "깊은 숲속의 잔잔한 공기처럼 차분하고 포근한 분위기를 전하는 향기입니다.",
+  },
+}
+
+export const LongText: Story = {
+  args: {
+    imageSrc:
+      "https://images.unsplash.com/photo-1528740561666-dc2479dc08ab?auto=format&fit=crop&w=800&q=80",
+    imageAlt: "플로럴 향기 이미지",
+    tags: ["Floral", "Soft", "Elegant", "Daily"],
+    title: "Blossom Dream With Long Title",
+    description:
+      "은은하게 퍼지는 꽃향기와 부드러운 머스크가 어우러져 일상 속에서도 부담 없이 사용할 수 있는 섬세한 향기입니다.",
+  },
+}

--- a/src/shared/components/archive-card/ArchiveCard.tsx
+++ b/src/shared/components/archive-card/ArchiveCard.tsx
@@ -1,0 +1,46 @@
+import { Tag } from "../tag"
+
+type ArchiveCardProps = {
+  imageSrc: string
+  imageAlt: string
+  tags: string[]
+  title: string
+  description: string
+}
+
+const ArchiveCard = ({
+  imageSrc,
+  imageAlt,
+  tags,
+  title,
+  description,
+}: ArchiveCardProps) => {
+  const visibleTags = tags.slice(0, 2)
+
+  return (
+    <article className="flex w-full flex-col gap-sm rounded-lg border border-border bg-card p-md shadow-box">
+      <div className="h-[200px] w-full overflow-hidden rounded-md">
+        <img
+          src={imageSrc}
+          alt={imageAlt}
+          className="h-full w-full object-cover"
+        />
+      </div>
+      <ul className="flex gap-xs">
+        {visibleTags.map((tag, index) => (
+          <li key={`${tag}-${index}`}>
+            <Tag label={tag} variant="soft" size="sm" />
+          </li>
+        ))}
+      </ul>
+      <div className="flex min-w-0 flex-col gap-xs">
+        <h2 className="truncate text-lg font-bold text-text-primary">
+          {title}
+        </h2>
+        <p className="line-clamp-2 text-sm text-text-sub">{description}</p>
+      </div>
+    </article>
+  )
+}
+
+export default ArchiveCard


### PR DESCRIPTION
## 📌 작업 내용

- ArchiveCard 컴포넌트 구현
- 이미지, 태그, 제목, 설명으로 구성된 카드 UI 작성
- 태그는 최대 2개만 노출되도록 처리
- 제목은 1줄 말줄임, 설명은 2줄 말줄임 적용
- 카드가 부모 컨테이너 너비를 기준으로 동작하도록 w-full 구조로 정리
- Storybook에서 240px 컨테이너 기준으로 확인할 수 있도록 decorator 적용
- LongText 케이스 포함해 스토리 작성 및 렌더 확인

## 🔗 관련 이슈

- closes #52 

## 📸 스크린샷 (선택)
<img width="1182" height="593" alt="image" src="https://github.com/user-attachments/assets/76b03df6-7e06-490a-9f3c-b843196a18b3" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
