### PR TITLE
feat: Note 컴포넌트 제작

### DIFF
--- a/src/shared/components/note-section/NoteSectionCard.stories.tsx
+++ b/src/shared/components/note-section/NoteSectionCard.stories.tsx
@@ -53,9 +53,9 @@ export const LongDescription: Story = {
 
 export const SeparatedCards: Story = {
   render: () => (
-    <div className="flex flex-col gap-lg" style={{ width: 520 }}>
+    <div className="flex flex-col gap-sm" style={{ width: 520 }}>
       {[1, 2, 3].map((i) => (
-        <div key={i} className="rounded-lg border border-border bg-white p-md">
+        <div key={i} className="rounded-lg border border-border bg-white p-lg">
           <NoteSectionCard {...defaultArgs} size="md" />
         </div>
       ))}
@@ -65,12 +65,12 @@ export const SeparatedCards: Story = {
 
 export const GroupedCard: Story = {
   render: () => (
-    <div className="rounded-[28px] bg-background p-lg" style={{ width: 380 }}>
+    <div className="rounded-lg bg-background p-lg w-full">
       <p className="text-sm font-semibold text-text-primary">
         NOTE COMPOSITION
       </p>
 
-      <div className="mt-md flex flex-col gap-lg">
+      <div className="mt-sm flex flex-col gap-sm">
         <NoteSectionCard {...defaultArgs} size="sm" />
         <NoteSectionCard {...defaultArgs} size="sm" />
         <NoteSectionCard {...defaultArgs} size="sm" />

--- a/src/shared/components/note-section/NoteSectionCard.stories.tsx
+++ b/src/shared/components/note-section/NoteSectionCard.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import NoteSectionCard from "./NoteSectionCard"
+
+const meta: Meta<typeof NoteSectionCard> = {
+  title: "components/NoteSectionCard",
+  component: NoteSectionCard,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof NoteSectionCard>
+
+const defaultArgs = {
+  labelEn: "TOP NOTES",
+  labelKo: "탑 노트",
+  description: "첫 인상을 결정하는 가벼운 향기",
+  tags: ["베르가못", "핑크 페퍼", "유칼립투스"],
+}
+
+export const Default: Story = {
+  args: {
+    ...defaultArgs,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 320 }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export const LongDescription: Story = {
+  args: {
+    ...defaultArgs,
+    size: "sm",
+    description:
+      "처음엔 가볍고 산뜻하게 시작되지만 시간이 지날수록 점점 더 풍부하고 섬세한 향의 층이 드러나는 매력적인 노트입니다.",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 280 }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export const SeparatedCards: Story = {
+  render: () => (
+    <div className="flex flex-col gap-lg" style={{ width: 520 }}>
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="rounded-lg border border-border bg-white p-md">
+          <NoteSectionCard {...defaultArgs} size="md" />
+        </div>
+      ))}
+    </div>
+  ),
+}
+
+export const GroupedCard: Story = {
+  render: () => (
+    <div className="rounded-[28px] bg-background p-lg" style={{ width: 380 }}>
+      <p className="text-sm font-semibold text-text-primary">
+        NOTE COMPOSITION
+      </p>
+
+      <div className="mt-md flex flex-col gap-lg">
+        <NoteSectionCard {...defaultArgs} size="sm" />
+        <NoteSectionCard {...defaultArgs} size="sm" />
+        <NoteSectionCard {...defaultArgs} size="sm" />
+      </div>
+    </div>
+  ),
+}

--- a/src/shared/components/note-section/NoteSectionCard.tsx
+++ b/src/shared/components/note-section/NoteSectionCard.tsx
@@ -1,0 +1,60 @@
+import cn from "@/lib/utils"
+import { Tag } from "@/shared/components/tag"
+
+type NoteSectionCardProps = {
+  labelEn: string
+  labelKo: string
+  description: string
+  tags: string[]
+  size?: "sm" | "md"
+  className?: string
+}
+
+const sizeStyles = {
+  sm: "text-md",
+  md: "text-lg",
+}
+
+const commonStyles = {
+  labelEn: "text-sm",
+  desc: "text-sm",
+  gap: "mt-xs",
+}
+
+export default function NoteSectionCard({
+  labelEn,
+  labelKo,
+  description,
+  tags,
+  size = "md",
+  className,
+}: NoteSectionCardProps) {
+  const s = {
+    title: sizeStyles[size],
+    ...commonStyles,
+  }
+
+  return (
+    <section className={cn("min-w-0", className)}>
+      {size === "md" && (
+        <p
+          className={cn("font-medium uppercase text-text-highlight", s.labelEn)}
+        >
+          {labelEn}
+        </p>
+      )}
+
+      <h3 className={cn("font-bold text-text-highlight", s.title)}>
+        {labelKo}
+      </h3>
+
+      <p className={cn("text-text-sub", s.desc)}>{description}</p>
+
+      <div className={cn("flex flex-wrap gap-xs", s.gap)}>
+        {tags.map((tag) => (
+          <Tag key={tag} label={tag} size="sm" variant="subtle" />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/shared/components/note-section/NoteSectionCard.tsx
+++ b/src/shared/components/note-section/NoteSectionCard.tsx
@@ -11,8 +11,8 @@ type NoteSectionCardProps = {
 }
 
 const sizeStyles = {
-  sm: "text-md",
-  md: "text-lg",
+  sm: "text-md font-bold",
+  md: "text-lg font-bold",
 }
 
 const commonStyles = {


### PR DESCRIPTION
## 📌 작업 내용

- Note 컴포넌트를 제작했습니다.
- Result 페이지와 Detail 페이지 두 군데에서 사용되기 때문에 shared 폴더에 넣었습니다.
  - 두 군데에서 사용하는 방식이 다르기 때문에 size props를 받아 구분하여 올릴 계획입니다. 스토리북에 예시를 올려두었습니다.

## 🔗 관련 이슈

- closes #58 

## 📸 스크린샷 (선택)
<img width="519" height="218" alt="image" src="https://github.com/user-attachments/assets/976aed74-dd44-4975-8d96-19a777a4421c" />
<img width="525" height="490" alt="image" src="https://github.com/user-attachments/assets/60443605-0fb8-42de-b665-db9e9393fde1" />
<img width="529" height="388" alt="image" src="https://github.com/user-attachments/assets/63493f5a-df70-47d2-8d49-c01e2ac8ca2d" />

## ✅ 체크리스트

- [x] 코드 컨벤션 확인
- [x] lint 에러 없음
- [x] 빌드 정상 확인
