### PR TITLE
feat: PreferenceSlider 컴포넌트 구현

### DIFF
--- a/src/features/scent-servey/page/ScentServey.tsx
+++ b/src/features/scent-servey/page/ScentServey.tsx
@@ -1,0 +1,5 @@
+const ScentServey = () => {
+  return <div>ScentServey</div>
+}
+
+export default ScentServey

--- a/src/features/scent-servey/page/preference-slider/PreferenceSlider.css
+++ b/src/features/scent-servey/page/preference-slider/PreferenceSlider.css
@@ -1,0 +1,38 @@
+.preference-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  outline: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.preference-slider::-webkit-slider-runnable-track {
+  height: 100%;
+  background: transparent;
+}
+
+.preference-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.preference-slider::-moz-range-track {
+  height: 100%;
+  background: transparent;
+}
+
+.preference-slider::-moz-range-thumb {
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}

--- a/src/features/scent-servey/page/preference-slider/PreferenceSlider.stories.tsx
+++ b/src/features/scent-servey/page/preference-slider/PreferenceSlider.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useArgs } from "storybook/preview-api"
+
+import PreferenceSlider from "./PreferenceSlider"
+
+const meta = {
+  title: "Components/PreferenceSlider",
+  component: PreferenceSlider,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[600px]">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    value: {
+      control: {
+        type: "range",
+        min: 0,
+        max: 4,
+        step: 1,
+      },
+    },
+    onChange: {
+      control: false,
+    },
+    className: {
+      control: false,
+    },
+  },
+} satisfies Meta<typeof PreferenceSlider>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    order: 1,
+    title: "아침에 선호하는 향",
+    description: "하루를 시작할 때 어떤 느낌의 향을 원하시나요?",
+    labels: [
+      "매우 상쾌함",
+      "약간 상쾌함",
+      "보통",
+      "약간 포근함",
+      "매우 포근함",
+    ],
+    edgeLabels: ["상쾌한", "포근한"],
+    value: 2,
+  },
+  render: function Render(args) {
+    const [{ value }, updateArgs] = useArgs()
+
+    return (
+      <PreferenceSlider
+        {...args}
+        value={value}
+        onChange={(nextValue) => {
+          updateArgs({ value: nextValue })
+        }}
+      />
+    )
+  },
+}

--- a/src/features/scent-servey/page/preference-slider/PreferenceSlider.tsx
+++ b/src/features/scent-servey/page/preference-slider/PreferenceSlider.tsx
@@ -1,0 +1,128 @@
+import clsx from "clsx"
+import "./PreferenceSlider.css"
+
+type PreferenceSliderProps = {
+  order: number
+  title: string
+  description: string
+  labels: [string, string, string, string, string]
+  edgeLabels?: [string, string]
+  value: number
+  onChange?: (value: number) => void
+  className?: string
+}
+
+const POINTS = [0, 1, 2, 3, 4] as const
+const LAST_POINT_INDEX = POINTS.length - 1
+
+const PreferenceSlider = ({
+  order,
+  title,
+  description,
+  labels,
+  edgeLabels,
+  value,
+  onChange,
+  className,
+}: PreferenceSliderProps) => {
+  const percentage = (value / LAST_POINT_INDEX) * 100
+  const selectedLabel = labels[value]
+  const [leftEdgeLabel, rightEdgeLabel] = edgeLabels ?? [labels[0], labels[4]]
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (!onChange) {
+      return
+    }
+
+    onChange(Number(event.target.value))
+  }
+
+  return (
+    <article
+      className={clsx(
+        "flex w-full flex-col gap-md rounded-2xl border border-border bg-card p-lg",
+        className
+      )}
+    >
+      <header className="flex items-start gap-sm">
+        <div className="flex mt-xs pt-xs h-xl w-xl shrink-0 items-center justify-center rounded-full bg-primary">
+          <span className="text-lg font-bold text-card">{order}</span>
+        </div>
+
+        <div className="flex flex-col">
+          <h3 className="text-lg font-bold text-text-primary">{title}</h3>
+          <p className="text-md text-text-sub">{description}</p>
+        </div>
+      </header>
+
+      <div className="flex flex-col px-xl pb-xl">
+        <div className="flex items-center justify-between text-md text-text-sub">
+          <span>{leftEdgeLabel}</span>
+          <span>{rightEdgeLabel}</span>
+        </div>
+
+        <div className="relative py-md">
+          <div className="pointer-events-none absolute inset-x-0 top-1/2 h-xs -translate-y-1/2 rounded-full bg-border" />
+
+          {POINTS.map((point) => {
+            const pointLeft = `${(point / LAST_POINT_INDEX) * 100}%`
+
+            return (
+              <span
+                key={`dot-${point}`}
+                className="pointer-events-none absolute top-1/2 z-10 h-md w-md -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-card bg-border"
+                style={{ left: pointLeft }}
+              />
+            )
+          })}
+
+          <span
+            className="pointer-events-none absolute top-1/2 z-20 h-xl w-xl -translate-x-1/2 -translate-y-1/2 rounded-full border-4 border-card bg-primary"
+            style={{ left: `${percentage}%` }}
+          />
+
+          {POINTS.map((point) => {
+            const pointLeft = `${(point / LAST_POINT_INDEX) * 100}%`
+
+            return (
+              <button
+                key={`button-${point}`}
+                type="button"
+                aria-label={labels[point]}
+                className="absolute top-1/2 z-30 h-xl w-xl -translate-x-1/2 -translate-y-1/2 rounded-full"
+                style={{ left: pointLeft }}
+                onClick={() => {
+                  if (!onChange) {
+                    return
+                  }
+
+                  onChange(point)
+                }}
+              />
+            )
+          })}
+
+          <input
+            type="range"
+            min={0}
+            max={LAST_POINT_INDEX}
+            step={1}
+            value={value}
+            onChange={handleChange}
+            aria-label={title}
+            className="preference-slider absolute inset-0 z-40"
+          />
+
+          <output
+            className="absolute top-full z-20 mt-sm -translate-x-1/2 whitespace-nowrap rounded-full border border-border bg-surface-container px-sm py-xs text-sm font-bold text-text-highlight shadow-sm"
+            style={{ left: `${percentage}%` }}
+          >
+            {selectedLabel}
+          </output>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+export default PreferenceSlider


### PR DESCRIPTION
## 📌 작업 내용

- 5단계 선택형 PreferenceSlider 컴포넌트 구현
- range 기반 드래그 및 포인트 클릭 선택 기능 추가
- 선택 상태 텍스트 pill UI 적용
- 스토리북 인터랙션 및 value control 연동

## 🔗 관련 이슈

- closes #79 

## 📸 스크린샷 (선택)
<img width="616" height="225" alt="GIF 2026-04-16 오전 1-16-39" src="https://github.com/user-attachments/assets/0b5efec6-2ba0-4805-b100-7c54c3d7ce48" />

## ✅ 체크리스트

- [x] 코드 컨벤션 확인
- [x] lint 에러 없음
- [x] 빌드 정상 확인