### PR TITLE
feat: 페이지에 Tab Section 추가

### DIFF
--- a/src/features/my-page/pages/MyPage.tsx
+++ b/src/features/my-page/pages/MyPage.tsx
@@ -6,6 +6,7 @@ import type { UserProfile } from "../types"
 import UserSection from "./user-section/UserSection"
 // index 필요
 import LoadingState from "@/shared/components/loading-state/LoadingState"
+import TabSection from "./tab-section/TabSection"
 
 export default function MyPage() {
   const [user, setUser] = useState<UserProfile | null>(null)
@@ -25,14 +26,16 @@ export default function MyPage() {
   }, [])
 
   return (
-    <FullScreen className="bg-surface-">
+    <FullScreen className="bg-surface-default">
       <CenterContainer className="w-full py-2xl">
         <Container
           width="xl"
           isPadded
-          className="h-screen max-w-container-xl border border-border bg-surface-default shadow-box"
+          className="h-screen max-w-container-xl bg-surface-default shadow-box"
         >
+          {/* 내부 영역 */}
           {!user ? <LoadingState /> : <UserSection user={user} />}
+          <TabSection />
         </Container>
       </CenterContainer>
     </FullScreen>

--- a/src/features/my-page/pages/sections/collection-section/CollectionSection.tsx
+++ b/src/features/my-page/pages/sections/collection-section/CollectionSection.tsx
@@ -1,0 +1,8 @@
+export default function CollectionSection() {
+  return (
+    <section>
+      <h2 className="text-md font-bold text-text-primary">저장된 향기 4개</h2>
+      <div className="mt-xl">컬렉션 카드 영역</div>
+    </section>
+  )
+}

--- a/src/features/my-page/pages/sections/history-section/HistorySection.tsx
+++ b/src/features/my-page/pages/sections/history-section/HistorySection.tsx
@@ -1,0 +1,8 @@
+export default function HistorySection() {
+  return (
+    <section>
+      <h2 className="text-md font-bold text-text-primary">내 기록</h2>
+      <div className="mt-xl">히스토리 카드 영역</div>
+    </section>
+  )
+}

--- a/src/features/my-page/pages/sections/index.ts
+++ b/src/features/my-page/pages/sections/index.ts
@@ -1,0 +1,3 @@
+export { default as CollectionSection } from "./collection-section/CollectionSection"
+export { default as HistorySection } from "./history-section/HistorySection"
+export { default as ReviewSection } from "./review-section/ReviewSection"

--- a/src/features/my-page/pages/sections/review-section/ReviewSection.tsx
+++ b/src/features/my-page/pages/sections/review-section/ReviewSection.tsx
@@ -1,0 +1,8 @@
+export default function ReviewSection() {
+  return (
+    <section>
+      <h2 className="text-md font-bold text-text-primary">리뷰</h2>
+      <div className="mt-xl">리뷰 카드 영역</div>
+    </section>
+  )
+}

--- a/src/features/my-page/pages/tab-section/TabSection.tsx
+++ b/src/features/my-page/pages/tab-section/TabSection.tsx
@@ -1,0 +1,26 @@
+import { useState } from "react"
+
+import {
+  CollectionSection,
+  HistorySection,
+  ReviewSection,
+} from "@/features/my-page/pages/sections"
+import Tab, { type TabKey } from "./tab/Tab"
+
+export default function TabSection() {
+  const [activeTab, setActiveTab] = useState<TabKey>("collection")
+
+  return (
+    <section className="mt-2xl">
+      <div className="flex flex-col justify-center items-center">
+        <Tab activeTab={activeTab} onChange={setActiveTab} />
+      </div>
+
+      <div className="mt-xl">
+        {activeTab === "collection" && <CollectionSection />}
+        {activeTab === "history" && <HistorySection />}
+        {activeTab === "review" && <ReviewSection />}
+      </div>
+    </section>
+  )
+}

--- a/src/features/my-page/pages/tab-section/tab/Tab.stories.tsx
+++ b/src/features/my-page/pages/tab-section/tab/Tab.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useState } from "react"
+
+import type { TabKey } from "./Tab"
+import Tab from "./Tab"
+
+const meta: Meta<typeof Tab> = {
+  title: "Components/Tab",
+  component: Tab,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    activeTab: {
+      control: "radio",
+      options: ["collection", "history", "review"],
+    },
+    onChange: { action: "changed" },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Tab>
+
+/**
+ * 기본 (컨트롤 기반)
+ */
+export const Default: Story = {
+  args: {
+    activeTab: "collection",
+  },
+}
+
+/**
+ * 인터랙션 가능한 스토리 (실제 상태 변화)
+ */
+export const Interactive: Story = {
+  render: (args) => {
+    const [activeTab, setActiveTab] = useState<TabKey>("collection")
+
+    return (
+      <Tab
+        {...args}
+        activeTab={activeTab}
+        onChange={(tab) => {
+          setActiveTab(tab)
+          args.onChange?.(tab)
+        }}
+      />
+    )
+  },
+}
+
+/**
+ * 각 상태별 스냅샷 확인용
+ */
+export const CollectionActive: Story = {
+  args: {
+    activeTab: "collection",
+  },
+}
+
+export const HistoryActive: Story = {
+  args: {
+    activeTab: "history",
+  },
+}
+
+export const ReviewActive: Story = {
+  args: {
+    activeTab: "review",
+  },
+}

--- a/src/features/my-page/pages/tab-section/tab/Tab.tsx
+++ b/src/features/my-page/pages/tab-section/tab/Tab.tsx
@@ -1,0 +1,67 @@
+import { cn } from "@/lib/utils"
+
+export type TabKey = "collection" | "history" | "review"
+
+type TabItem = {
+  key: TabKey
+  label: string
+}
+
+type TabProps = {
+  activeTab: TabKey
+  onChange: (tab: TabKey) => void
+  className?: string
+}
+
+const tabItems: TabItem[] = [
+  { key: "collection", label: "컬렉션" },
+  { key: "history", label: "내 기록" },
+  { key: "review", label: "리뷰" },
+]
+
+const tabIndexMap: Record<TabKey, number> = {
+  collection: 0,
+  history: 1,
+  review: 2,
+}
+
+export default function Tab({ activeTab, onChange, className }: TabProps) {
+  const activeIndex = tabIndexMap[activeTab]
+
+  return (
+    <div
+      className={cn(
+        "relative w-full grid grid-cols-3 rounded-full bg-badge p-xs",
+        className
+      )}
+    >
+      {/* moving pill */}
+      <div
+        className="absolute top-xs left-xs h-[calc(100%-8px)] w-[calc(33.333%-4px)] rounded-full bg-white shadow-box transition-transform duration-300"
+        style={{
+          transform: `translateX(${activeIndex * 100}%)`,
+        }}
+      />
+
+      {tabItems.map((tab) => {
+        const isActive = activeTab === tab.key
+
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => onChange(tab.key)}
+            className={cn(
+              "relative z-10 rounded-full px-md py-sm text-sm font-semibold transition-colors",
+              isActive
+                ? "text-text-primary"
+                : "text-text-disabled hover:text-text-primary"
+            )}
+          >
+            {tab.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/features/root/layout/RootLayout.tsx
+++ b/src/features/root/layout/RootLayout.tsx
@@ -1,15 +1,11 @@
-import Footer from "@/features/_wide/layout/footer/Footer"
-import Header from "@/features/_wide/layout/header/Header"
 import { Toaster } from "@/shared/components/toast"
 import { Outlet } from "@tanstack/react-router"
 
 const RootLayout = () => {
   return (
     <>
-      <Header />
       <Outlet />
       <Toaster />
-      <Footer />
     </>
   )
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,16 +9,11 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as MyPageRouteImport } from './routes/my-page'
 import { Route as WideRouteImport } from './routes/_wide'
 import { Route as WideIndexRouteImport } from './routes/_wide.index'
 import { Route as WideNotRealRouteImport } from './routes/_wide.not-real'
+import { Route as WideMyPageRouteImport } from './routes/_wide.my-page'
 
-const MyPageRoute = MyPageRouteImport.update({
-  id: '/my-page',
-  path: '/my-page',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const WideRoute = WideRouteImport.update({
   id: '/_wide',
   getParentRoute: () => rootRouteImport,
@@ -33,21 +28,26 @@ const WideNotRealRoute = WideNotRealRouteImport.update({
   path: '/not-real',
   getParentRoute: () => WideRoute,
 } as any)
+const WideMyPageRoute = WideMyPageRouteImport.update({
+  id: '/my-page',
+  path: '/my-page',
+  getParentRoute: () => WideRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof WideIndexRoute
-  '/my-page': typeof MyPageRoute
+  '/my-page': typeof WideMyPageRoute
   '/not-real': typeof WideNotRealRoute
 }
 export interface FileRoutesByTo {
-  '/my-page': typeof MyPageRoute
+  '/my-page': typeof WideMyPageRoute
   '/not-real': typeof WideNotRealRoute
   '/': typeof WideIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_wide': typeof WideRouteWithChildren
-  '/my-page': typeof MyPageRoute
+  '/_wide/my-page': typeof WideMyPageRoute
   '/_wide/not-real': typeof WideNotRealRoute
   '/_wide/': typeof WideIndexRoute
 }
@@ -56,23 +56,15 @@ export interface FileRouteTypes {
   fullPaths: '/' | '/my-page' | '/not-real'
   fileRoutesByTo: FileRoutesByTo
   to: '/my-page' | '/not-real' | '/'
-  id: '__root__' | '/_wide' | '/my-page' | '/_wide/not-real' | '/_wide/'
+  id: '__root__' | '/_wide' | '/_wide/my-page' | '/_wide/not-real' | '/_wide/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   WideRoute: typeof WideRouteWithChildren
-  MyPageRoute: typeof MyPageRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/my-page': {
-      id: '/my-page'
-      path: '/my-page'
-      fullPath: '/my-page'
-      preLoaderRoute: typeof MyPageRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/_wide': {
       id: '/_wide'
       path: ''
@@ -94,15 +86,24 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WideNotRealRouteImport
       parentRoute: typeof WideRoute
     }
+    '/_wide/my-page': {
+      id: '/_wide/my-page'
+      path: '/my-page'
+      fullPath: '/my-page'
+      preLoaderRoute: typeof WideMyPageRouteImport
+      parentRoute: typeof WideRoute
+    }
   }
 }
 
 interface WideRouteChildren {
+  WideMyPageRoute: typeof WideMyPageRoute
   WideNotRealRoute: typeof WideNotRealRoute
   WideIndexRoute: typeof WideIndexRoute
 }
 
 const WideRouteChildren: WideRouteChildren = {
+  WideMyPageRoute: WideMyPageRoute,
   WideNotRealRoute: WideNotRealRoute,
   WideIndexRoute: WideIndexRoute,
 }
@@ -111,7 +112,6 @@ const WideRouteWithChildren = WideRoute._addFileChildren(WideRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
   WideRoute: WideRouteWithChildren,
-  MyPageRoute: MyPageRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/_wide.my-page.tsx
+++ b/src/routes/_wide.my-page.tsx
@@ -1,6 +1,6 @@
 import MyPage from "@/features/my-page/pages/MyPage"
 import { createFileRoute } from "@tanstack/react-router"
 
-export const Route = createFileRoute("/my-page")({
+export const Route = createFileRoute("/_wide/my-page")({
   component: MyPage,
 })


### PR DESCRIPTION
## 📌 작업 내용

- Tab 섹션의 스켈레톤을 제작했습니다.
- Tab Section 상단의 컴포넌트를 제작했습니다. 탭을 클릭하면 해당 섹션이 보여지는 방식입니다. 
  - Pill에 애니메이션을 추가하여 전환이 자연스럽게 보이도록 했습니다.
 
- RootLayout에 있는 헤더와 푸터를 삭제했습니다.

## 🔗 관련 이슈

- closes #91 

## 📸 스크린샷 (선택)
<img width="845" height="722" alt="image" src="https://github.com/user-attachments/assets/0ed71c11-9591-441f-83ae-84a65a304ce2" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
