### PR TITLE
feat: main page 레이아웃 구성 (기능 없이)

### DIFF
--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,85 @@
+import { Accordion as AccordionPrimitive } from "radix-ui"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+
+function Accordion({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return (
+    <AccordionPrimitive.Root
+      data-slot="accordion"
+      className={cn("flex w-full flex-col", className)}
+      {...props}
+    />
+  )
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("not-last:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "group/accordion-trigger relative flex flex-1 items-start justify-between rounded-lg border border-transparent py-2.5 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:after:border-ring disabled:pointer-events-none disabled:opacity-50 **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 **:data-[slot=accordion-trigger-icon]:text-muted-foreground",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDownIcon
+          data-slot="accordion-trigger-icon"
+          className="pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+        />
+        <ChevronUpIcon
+          data-slot="accordion-trigger-icon"
+          className="pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+        />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  )
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className="overflow-hidden text-sm data-open:animate-accordion-down data-closed:animate-accordion-up"
+      {...props}
+    >
+      <div
+        className={cn(
+          "h-(--radix-accordion-content-height) pt-0 pb-2.5 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+          className
+        )}
+      >
+        {children}
+      </div>
+    </AccordionPrimitive.Content>
+  )
+}
+
+export { Accordion, AccordionContent, AccordionItem, AccordionTrigger }

--- a/src/features/_wide.index/page/1-introduction/Introduction.tsx
+++ b/src/features/_wide.index/page/1-introduction/Introduction.tsx
@@ -1,0 +1,18 @@
+import { Button, Vstack } from "@/shared/components"
+
+const Introduction = () => {
+  return (
+    <Vstack className="h-125 items-center p-2xl justify-between bg-amber-50">
+      <Vstack className="justify-start w-full">
+        <h1>내 공간을 완성해줄 마지막 한 조각</h1>
+        <p>가장 편안한 공간의 사진 한 장,</p>
+        <p>혹은 지금의 기분만 들려주세요.</p>
+        <p>당신의 취향 조각들을 모아</p>
+        <p>공간을 완벽하게 마무리 해줄 향기를 찾아낼게요.</p>
+      </Vstack>
+      <Button>나의 마지막 조각 찾기</Button>
+    </Vstack>
+  )
+}
+
+export default Introduction

--- a/src/features/_wide.index/page/2-find-your-scent/FindYourScent.tsx
+++ b/src/features/_wide.index/page/2-find-your-scent/FindYourScent.tsx
@@ -1,0 +1,21 @@
+import { Vstack } from "@/shared/components"
+
+const FindYourScent = () => {
+  // TODO: 뷰포트 좁아지면 그리드를 Vstack으로 바꿔야 함
+  // TODO: 이 때는 세로로 긴 상자 없이 둘 다 글 왼쪽 그림 오른쪽으로 배치해야
+  return (
+    <Vstack className="px-2xl">
+      <p>나만의 향기를 발견하는 세 가지 방법</p>
+      <h1>당신만의 향기를 발견해 보세요</h1>
+      <p>가장 편안한 방식으로 당신의 취향을 찾아보세요.</p>
+
+      <div className="gap-xl grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))]">
+        <div className="bg-amber-50 h-87.5 col-span-2">some content</div>
+        <div className="bg-amber-50 h-87.5">some content</div>
+        <div className="bg-amber-50 h-87.5">some content</div>
+      </div>
+    </Vstack>
+  )
+}
+
+export default FindYourScent

--- a/src/features/_wide.index/page/2-find-your-scent/FindYourScent.tsx
+++ b/src/features/_wide.index/page/2-find-your-scent/FindYourScent.tsx
@@ -1,20 +1,20 @@
-import { Vstack } from "@/shared/components"
+import SectionVstack from "../section-container/SectionContainer"
 
 const FindYourScent = () => {
   // TODO: 뷰포트 좁아지면 그리드를 Vstack으로 바꿔야 함
   // TODO: 이 때는 세로로 긴 상자 없이 둘 다 글 왼쪽 그림 오른쪽으로 배치해야
   return (
-    <Vstack className="px-2xl">
+    <SectionVstack>
       <p>나만의 향기를 발견하는 세 가지 방법</p>
       <h1>당신만의 향기를 발견해 보세요</h1>
       <p>가장 편안한 방식으로 당신의 취향을 찾아보세요.</p>
 
       <div className="gap-xl grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))]">
-        <div className="bg-amber-50 h-87.5 col-span-2">some content</div>
-        <div className="bg-amber-50 h-87.5">some content</div>
-        <div className="bg-amber-50 h-87.5">some content</div>
+        <div className="bg-amber-100 h-87.5 col-span-2">some content</div>
+        <div className="bg-amber-100 h-87.5">some content</div>
+        <div className="bg-amber-100 h-87.5">some content</div>
       </div>
-    </Vstack>
+    </SectionVstack>
   )
 }
 

--- a/src/features/_wide.index/page/3-view-all-scents/ViewAllScents.tsx
+++ b/src/features/_wide.index/page/3-view-all-scents/ViewAllScents.tsx
@@ -1,5 +1,21 @@
+import { Button, Hstack } from "@/shared/components"
+import { Compass } from "lucide-react"
+import SectionVstack from "../section-container/SectionContainer"
+
 const ViewAllScents = () => {
-  return <div>this is view all sscents</div>
+  return (
+    <SectionVstack className="items-center">
+      <Compass />
+      <p>Curated</p>
+      <h2>지금 가장 사랑받는 향기들</h2>
+      <p>누군가의 공간을 완성했던 향기 조각들을 만나보세요.</p>
+      <p>기분과 장소, 그리고 찰나의 순간을 위해 엄선했습니다.</p>
+      <Hstack gap="none">
+        <Button isContained={false}>View all</Button>
+        <Button>Scroll</Button>
+      </Hstack>
+    </SectionVstack>
+  )
 }
 
 export default ViewAllScents

--- a/src/features/_wide.index/page/3-view-all-scents/ViewAllScents.tsx
+++ b/src/features/_wide.index/page/3-view-all-scents/ViewAllScents.tsx
@@ -1,0 +1,5 @@
+const ViewAllScents = () => {
+  return <div>this is view all sscents</div>
+}
+
+export default ViewAllScents

--- a/src/features/_wide.index/page/4-quick-start/QuickStart.tsx
+++ b/src/features/_wide.index/page/4-quick-start/QuickStart.tsx
@@ -8,7 +8,8 @@ const QuickStart = () => {
       <h2>간편한 시작</h2>
       <h3>fragmnt 이렇게 사용해보세요</h3>
       <p>세 번의 과정으로 당신의 공간에 딱 맞는 향기를 찾아보세요.</p>
-      <Hstack gap="xl">
+
+      <Hstack gap="xl" className="w-full">
         <RoundBox radius="lg" className="bg-amber-200 w-full">
           card content placeholder
         </RoundBox>
@@ -19,6 +20,7 @@ const QuickStart = () => {
           card content placeholder
         </RoundBox>
       </Hstack>
+
       <Hstack gap="none">
         <Button isContained={false}>Start now</Button>
         <Button>

--- a/src/features/_wide.index/page/4-quick-start/QuickStart.tsx
+++ b/src/features/_wide.index/page/4-quick-start/QuickStart.tsx
@@ -19,12 +19,12 @@ const QuickStart = () => {
           card content placeholder
         </RoundBox>
       </Hstack>
-      <Hstack>
-        <Button>Start now</Button>
+      <Hstack gap="none">
+        <Button isContained={false}>Start now</Button>
         <Button>
-          <Hstack>
+          <Hstack gap="sm" className="items-center">
             <p>Learn more</p>
-            <ChevronRight size={16} />
+            <ChevronRight />
           </Hstack>
         </Button>
       </Hstack>

--- a/src/features/_wide.index/page/4-quick-start/QuickStart.tsx
+++ b/src/features/_wide.index/page/4-quick-start/QuickStart.tsx
@@ -1,5 +1,35 @@
+import { Button, Hstack, RoundBox } from "@/shared/components"
+import { ChevronRight } from "lucide-react"
+import SectionVstack from "../section-container/SectionContainer"
+
 const QuickStart = () => {
-  return <div>this is quickstart</div>
+  return (
+    <SectionVstack>
+      <h2>간편한 시작</h2>
+      <h3>fragmnt 이렇게 사용해보세요</h3>
+      <p>세 번의 과정으로 당신의 공간에 딱 맞는 향기를 찾아보세요.</p>
+      <Hstack gap="xl">
+        <RoundBox radius="lg" className="bg-amber-200 w-full">
+          card content placeholder
+        </RoundBox>
+        <RoundBox radius="lg" className="bg-amber-200 w-full">
+          card content placeholder
+        </RoundBox>
+        <RoundBox radius="lg" className="bg-amber-200 w-full">
+          card content placeholder
+        </RoundBox>
+      </Hstack>
+      <Hstack>
+        <Button>Start now</Button>
+        <Button>
+          <Hstack>
+            <p>Learn more</p>
+            <ChevronRight size={16} />
+          </Hstack>
+        </Button>
+      </Hstack>
+    </SectionVstack>
+  )
 }
 
 export default QuickStart

--- a/src/features/_wide.index/page/4-quick-start/QuickStart.tsx
+++ b/src/features/_wide.index/page/4-quick-start/QuickStart.tsx
@@ -4,7 +4,7 @@ import SectionVstack from "../section-container/SectionContainer"
 
 const QuickStart = () => {
   return (
-    <SectionVstack>
+    <SectionVstack className="items-center">
       <h2>간편한 시작</h2>
       <h3>fragmnt 이렇게 사용해보세요</h3>
       <p>세 번의 과정으로 당신의 공간에 딱 맞는 향기를 찾아보세요.</p>

--- a/src/features/_wide.index/page/4-quick-start/QuickStart.tsx
+++ b/src/features/_wide.index/page/4-quick-start/QuickStart.tsx
@@ -1,0 +1,5 @@
+const QuickStart = () => {
+  return <div>this is quickstart</div>
+}
+
+export default QuickStart

--- a/src/features/_wide.index/page/5-customer-reviews/CustomerReviews.tsx
+++ b/src/features/_wide.index/page/5-customer-reviews/CustomerReviews.tsx
@@ -1,0 +1,5 @@
+const CustomerReviews = () => {
+  return <div>this is customer reviews</div>
+}
+
+export default CustomerReviews

--- a/src/features/_wide.index/page/5-customer-reviews/CustomerReviews.tsx
+++ b/src/features/_wide.index/page/5-customer-reviews/CustomerReviews.tsx
@@ -1,5 +1,37 @@
+import { Hstack, RoundBox } from "@/shared/components"
+import { ChevronLeft, ChevronRight } from "lucide-react"
+import SectionVstack from "../section-container/SectionContainer"
+
+const ReviewCard = () => {
+  return (
+    <RoundBox padding="none" className="w-60 h-90 shrink-0 bg-amber-100">
+      review card placeholder
+    </RoundBox>
+  )
+}
+
+// TODO: RoundButton 공통 컴포넌트 만들어야(기존 button 확장하든, 새로 만들든)
 const CustomerReviews = () => {
-  return <div>this is customer reviews</div>
+  return (
+    <SectionVstack>
+      <h2>고객 후기</h2>
+      <Hstack className="justify-end">
+        <button>
+          <ChevronLeft />
+        </button>
+        <button>
+          <ChevronRight />
+        </button>
+      </Hstack>
+      <Hstack className="overflow-hidden">
+        {Array(10)
+          .fill(0)
+          .map((_, index) => (
+            <ReviewCard key={index} />
+          ))}
+      </Hstack>
+    </SectionVstack>
+  )
 }
 
 export default CustomerReviews

--- a/src/features/_wide.index/page/6-faq/FAQ.tsx
+++ b/src/features/_wide.index/page/6-faq/FAQ.tsx
@@ -1,0 +1,5 @@
+const FAQ = () => {
+  return <div>this is faq</div>
+}
+
+export default FAQ

--- a/src/features/_wide.index/page/6-faq/FAQ.tsx
+++ b/src/features/_wide.index/page/6-faq/FAQ.tsx
@@ -1,5 +1,42 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion"
+import { Button } from "@/shared/components"
+import SectionVstack from "../section-container/SectionContainer"
 const FAQ = () => {
-  return <div>this is faq</div>
+  return (
+    <SectionVstack className="items-center">
+      <h1>자주 묻는 질문</h1>
+      <h2>Fragmnt 서비스에 대해 궁금한 점을 확인해보세요.</h2>
+      <Accordion type="single" collapsible defaultValue="item-1">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Is it accessible?</AccordionTrigger>
+          <AccordionContent>
+            Yes. It adheres to the WAI-ARIA design pattern.
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="item-2">
+          <AccordionTrigger>Is it accessible?</AccordionTrigger>
+          <AccordionContent>
+            Yes. It adheres to the WAI-ARIA design pattern.
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="item-3">
+          <AccordionTrigger>Is it accessible?</AccordionTrigger>
+          <AccordionContent>
+            Yes. It adheres to the WAI-ARIA design pattern.
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+      <p>원하시는 답변을 찾지 못했나요?</p>
+      <Button shape="pill" isContained={false}>
+        문의하기
+      </Button>
+    </SectionVstack>
+  )
 }
 
 export default FAQ

--- a/src/features/_wide.index/page/MainPage.tsx
+++ b/src/features/_wide.index/page/MainPage.tsx
@@ -8,7 +8,7 @@ import FAQ from "./6-faq/FAQ"
 
 const MainPage = () => {
   return (
-    <Vstack gap="2xl">
+    <Vstack gap="2xl" className="pb-2xl">
       <Introduction />
       <FindYourScent />
       <ViewAllScents />

--- a/src/features/_wide.index/page/MainPage.tsx
+++ b/src/features/_wide.index/page/MainPage.tsx
@@ -1,15 +1,21 @@
-import { Button } from "@/shared/components"
-import { useNavigate } from "@tanstack/react-router"
+import { Button, Vstack } from "@/shared/components"
 
 const MainPage = () => {
-  const navigate = useNavigate()
   return (
-    <div>
-      <p>this is main page placeholder</p>
-      <Button onClick={() => navigate({ to: "/not-real" })}>
-        navigate to "not-real" page
-      </Button>
-    </div>
+    <Vstack gap="2xl">
+      <div className="bg-amber-50">
+        <Vstack className="h-125 items-center p-2xl justify-between">
+          <Vstack className="justify-start w-full">
+            <h1>내 공간을 완성해줄 마지막 한 조각</h1>
+            <p>가장 편안한 공간의 사진 한 장,</p>
+            <p>혹은 지금의 기분만 들려주세요.</p>
+            <p>당신의 취향 조각들을 모아</p>
+            <p>공간을 완벽하게 마무리 해줄 향기를 찾아낼게요.</p>
+          </Vstack>
+          <Button>나의 마지막 조각 찾기</Button>
+        </Vstack>
+      </div>
+    </Vstack>
   )
 }
 

--- a/src/features/_wide.index/page/MainPage.tsx
+++ b/src/features/_wide.index/page/MainPage.tsx
@@ -1,20 +1,20 @@
-import { Button, Vstack } from "@/shared/components"
+import { Vstack } from "@/shared/components"
+import Introduction from "./1-introduction/Introduction"
+import FindYourScent from "./2-find-your-scent/FindYourScent"
+import ViewAllScents from "./3-view-all-scents/ViewAllScents"
+import QuickStart from "./4-quick-start/QuickStart"
+import CustomerReviews from "./5-customer-reviews/CustomerReviews"
+import FAQ from "./6-faq/FAQ"
 
 const MainPage = () => {
   return (
     <Vstack gap="2xl">
-      <div className="bg-amber-50">
-        <Vstack className="h-125 items-center p-2xl justify-between">
-          <Vstack className="justify-start w-full">
-            <h1>내 공간을 완성해줄 마지막 한 조각</h1>
-            <p>가장 편안한 공간의 사진 한 장,</p>
-            <p>혹은 지금의 기분만 들려주세요.</p>
-            <p>당신의 취향 조각들을 모아</p>
-            <p>공간을 완벽하게 마무리 해줄 향기를 찾아낼게요.</p>
-          </Vstack>
-          <Button>나의 마지막 조각 찾기</Button>
-        </Vstack>
-      </div>
+      <Introduction />
+      <FindYourScent />
+      <ViewAllScents />
+      <QuickStart />
+      <CustomerReviews />
+      <FAQ />
     </Vstack>
   )
 }

--- a/src/features/_wide.index/page/MainPage.tsx
+++ b/src/features/_wide.index/page/MainPage.tsx
@@ -12,6 +12,7 @@ const MainPage = () => {
       <Introduction />
       <FindYourScent />
       <ViewAllScents />
+      <div>perfume image placeholder</div>
       <QuickStart />
       <CustomerReviews />
       <FAQ />

--- a/src/features/_wide.index/page/section-container/SectionContainer.tsx
+++ b/src/features/_wide.index/page/section-container/SectionContainer.tsx
@@ -1,0 +1,17 @@
+import { Vstack } from "@/shared/components"
+import clsx from "clsx"
+import type { ReactNode } from "react"
+
+type SectionVstackProps = {
+  children: ReactNode
+  className?: string
+}
+const SectionVstack = ({ children, className }: SectionVstackProps) => {
+  return (
+    <Vstack gap="xl" className={clsx("px-2xl bg-amber-50", className)}>
+      {children}
+    </Vstack>
+  )
+}
+
+export default SectionVstack

--- a/src/shared/components/fade-up-item/FadeUpItem.css
+++ b/src/shared/components/fade-up-item/FadeUpItem.css
@@ -1,0 +1,20 @@
+.blur-drop {
+  animation-name: blur-drop;
+  animation-duration: 0.5s;
+  animation-timing-function: cubic-bezier(0.08, 0.34, 0.26, 1.11);
+}
+
+@keyframes blur-drop {
+  from {
+    -webkit-filter: blur(50px);
+    transform: translateY(-100px);
+    scale: 110%;
+    opacity: 0%;
+  }
+  to {
+    -webkit-filter: blur(0);
+    transform: translateY(0);
+    scale: 100%;
+    opacity: 100%;
+  }
+}


### PR DESCRIPTION
## 📌 작업 내용

- 메인 페이지 레이아웃 설정
- shadcn/ui 의 accordion 설치

## 🔗 관련 이슈

- closes #93

## 📸 스크린샷 (선택)
<img width="1314" height="895" alt="image" src="https://github.com/user-attachments/assets/9f660d07-7e69-49ff-b3b0-e88de2a110fc" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
