### PR TITLE
fix: 와이드 레이아웃의 스크롤 영역 수정

### DIFF
--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,4 +1,12 @@
 import { Accordion as AccordionPrimitive } from "radix-ui"
+// NOTE: (채현님) 보통 accordian은 컴포넌트 구조 깨짐을 방지하기 위해서
+// `import * as AccordionPrimitive from "@radix-ui/react-accordion"`
+// 이런식으로 불러오는 게 맞다고 합니다!
+// (관련 문서)
+// TODO:
+// 그렇군요!
+// 그렇다면 shadcn에서 명령어로 설치를 한 다음에 import 문들을 수정하는 게 좋을까요?
+// 아니면 accordion 에만 해당되는 내용일까요?
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/src/features/_wide/layout/WideLayout.tsx
+++ b/src/features/_wide/layout/WideLayout.tsx
@@ -5,28 +5,49 @@ import {
   Vstack,
 } from "@/shared/components"
 import { Outlet } from "@tanstack/react-router"
+import type { ReactNode } from "react"
 import Footer from "./footer/Footer"
 import Header from "./header/Header"
 import NavigationBar from "./navigation-bar/NavigationBar"
 
+type ContainerForScrollbarGutterProps = {
+  children: ReactNode
+}
+const ContainerForScrollbarGutter = ({
+  children,
+}: ContainerForScrollbarGutterProps) => {
+  // NOTE: scrollbar 유무에 따른 header와 본문의 중앙 위치 어긋남을 방지합니다
+  return (
+    <div className="shrink-0 overflow-y-scroll">
+      <Container>{children}</Container>
+    </div>
+  )
+}
+
 const WideLayout = () => {
   return (
     <FullScreen>
-      <Container>
-        <Vstack
-          gap="none"
-          className="max-h-screen overflow-hidden bg-surface-default"
-        >
+      <Vstack gap="none" className="h-screen overflow-hidden">
+        <ContainerForScrollbarGutter>
           <Header />
-          <FlexOneContainer isYScrollable>
-            <Vstack gap="none" className="h-full justify-between">
+        </ContainerForScrollbarGutter>
+
+        <FlexOneContainer isYScrollable>
+          <Container className="h-full">
+            <Vstack
+              gap="none"
+              className="h-full justify-between bg-surface-default"
+            >
               <Outlet />
               <Footer />
             </Vstack>
-          </FlexOneContainer>
+          </Container>
+        </FlexOneContainer>
+
+        <ContainerForScrollbarGutter>
           <NavigationBar />
-        </Vstack>
-      </Container>
+        </ContainerForScrollbarGutter>
+      </Vstack>
     </FullScreen>
   )
 }

--- a/src/features/_wide/layout/WideLayout.tsx
+++ b/src/features/_wide/layout/WideLayout.tsx
@@ -11,9 +11,12 @@ import NavigationBar from "./navigation-bar/NavigationBar"
 
 const WideLayout = () => {
   return (
-    <FullScreen className="overflow-hidden">
-      <Container className="overflow-hidden h-full bg-surface-default">
-        <Vstack gap="none" className="overflow-hidden h-full">
+    <FullScreen>
+      <Container>
+        <Vstack
+          gap="none"
+          className="max-h-screen overflow-hidden bg-surface-default"
+        >
           <Header />
           <FlexOneContainer isYScrollable>
             <Vstack gap="none" className="h-full justify-between">

--- a/src/features/_wide/layout/WideLayout.tsx
+++ b/src/features/_wide/layout/WideLayout.tsx
@@ -36,7 +36,7 @@ const WideLayout = () => {
           <Container className="h-full">
             <Vstack
               gap="none"
-              className="h-full justify-between bg-surface-default"
+              className="min-h-full justify-between bg-surface-default"
             >
               <Outlet />
               <Footer />

--- a/src/features/_wide/layout/navigation-bar/NavigationBar.tsx
+++ b/src/features/_wide/layout/navigation-bar/NavigationBar.tsx
@@ -31,7 +31,7 @@ const NavigationButton = ({
   const isSelected = currentPathname === pathname
   const navigate = useNavigate()
   return (
-    <Link to={pathname} className="w-full hover:bg-gray-5 transition">
+    <Link to={pathname} className="w-full hover:bg-gray-5 transition pt-sm">
       <Vstack gap="none" className="items-center">
         <Icon
           size={40}

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,8 @@
 @custom-variant dark (&: is(.dark *));
 
 :root {
+  scrollbar-color: hsl(0 0 50) transparent;
+
   /* =====================================================
    PRIMITIVE COLOR TOKENS (절대값)
   ===================================================== */


### PR DESCRIPTION
## 📌 작업 내용

- 스크롤 영역 수정
- 스크롤바 색상 css 수정
- 내비게이션 바 상단 패딩 추가
    - 스크롤바 영역을 강제로 만들기 위해 overflow-y-scroll을 주기 위함

## 🔗 관련 이슈

- closes #98 

## 📸 스크린샷 (선택)
<img width="1160" height="788" alt="image" src="https://github.com/user-attachments/assets/25b57ec4-c656-49f1-86ab-26cb70c21881" />
<img width="1122" height="536" alt="image" src="https://github.com/user-attachments/assets/eba74cb3-0dd1-4473-8c70-3ab935d56124" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
