### PR TITLE
feat: 키워드로 찾기 페이지 ui 구현

### DIFF
--- a/.tanstack/tmp/30a50c92-c4418063fdd20c80fa7eaf9a37344c7a
+++ b/.tanstack/tmp/30a50c92-c4418063fdd20c80fa7eaf9a37344c7a
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_wide/scent-keyword')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return <div>Hello "/_wide/scent-keyword"!</div>
+}

--- a/src/features/find-scent/page/FindScent.tsx
+++ b/src/features/find-scent/page/FindScent.tsx
@@ -1,5 +1,5 @@
 import {
-  CenterContainer,
+  Container,
   FadeUpItem,
   Hstack,
   PageIntro,
@@ -45,7 +45,7 @@ const FindScent = () => {
 
   return (
     <>
-      <CenterContainer className="w-[850px] pt-16 pb-60">
+      <Container className=" pt-16 pb-60">
         <Vstack gap="none" className="gap-20">
           <PageIntro
             title="어떤 방식으로 향기를 찾을까요?"
@@ -63,7 +63,7 @@ const FindScent = () => {
             ))}
           </Hstack>
         </Vstack>
-      </CenterContainer>
+      </Container>
 
       <FindMethodModal
         isOpen={isKeywordModalOpen}

--- a/src/features/scent-keyword/data/scent-keyword-mock-data.ts
+++ b/src/features/scent-keyword/data/scent-keyword-mock-data.ts
@@ -1,0 +1,68 @@
+export type KeywordItem = {
+  keywordId: number
+  keywordName: string
+}
+
+export type KeywordSection = {
+  title: string
+  keywordDivision: string
+  keywords: KeywordItem[]
+}
+
+export const scentKeywordMockData: KeywordSection[] = [
+  {
+    title: "PLACE",
+    keywordDivision: "Place",
+    keywords: [
+      { keywordId: 1, keywordName: "안락한 침실" },
+      { keywordId: 2, keywordName: "화사한 거실" },
+      { keywordId: 3, keywordName: "집중의 서재" },
+      { keywordId: 4, keywordName: "청결한 욕실/현관" },
+      { keywordId: 5, keywordName: "프라이빗 드레스룸" },
+    ],
+  },
+  {
+    title: "MOOD",
+    keywordDivision: "MD",
+    keywords: [
+      { keywordId: 6, keywordName: "미니멀 & 정제된" },
+      { keywordId: 7, keywordName: "우아함 & 고급스러운" },
+      { keywordId: 8, keywordName: "로맨틱 & 달콤한" },
+      { keywordId: 9, keywordName: "내추럴 & 안정적인" },
+      { keywordId: 10, keywordName: "볼드 & 강렬한" },
+    ],
+  },
+  {
+    title: "TEXTURE",
+    keywordDivision: "Texture",
+    keywords: [
+      { keywordId: 11, keywordName: "보송한 리넨" },
+      { keywordId: 12, keywordName: "매끄러운 벨벳" },
+      { keywordId: 13, keywordName: "드라이한 나무" },
+      { keywordId: 14, keywordName: "촉촉한 이슬" },
+      { keywordId: 15, keywordName: "포근한 캐시미어" },
+    ],
+  },
+  {
+    title: "TIME & SEASON",
+    keywordDivision: "Time & Season",
+    keywords: [
+      { keywordId: 16, keywordName: "눈부신 아침" },
+      { keywordId: 17, keywordName: "고요한 저녁" },
+      { keywordId: 18, keywordName: "싱그러운 봄/여름" },
+      { keywordId: 19, keywordName: "깊어지는 가을/겨울" },
+      { keywordId: 20, keywordName: "비 온 뒤" },
+    ],
+  },
+  {
+    title: "SCENT NOTES",
+    keywordDivision: "Scent Notes",
+    keywords: [
+      { keywordId: 21, keywordName: "시트러스 (상쾌함)" },
+      { keywordId: 22, keywordName: "우디 (묵직함)" },
+      { keywordId: 23, keywordName: "플로럴 (화사함)" },
+      { keywordId: 24, keywordName: "머스크 (포근함)" },
+      { keywordId: 25, keywordName: "허벌 & 스파이시 (개성)" },
+    ],
+  },
+]

--- a/src/features/scent-keyword/page/ScentKeyword.tsx
+++ b/src/features/scent-keyword/page/ScentKeyword.tsx
@@ -1,0 +1,75 @@
+import {
+  BackButton,
+  Button,
+  Container,
+  PageIntro,
+  Vstack,
+} from "@/shared/components"
+import { useState } from "react"
+import KeywordSelectionSection from "./keyword-selection-section/KeywordSelectionSection"
+import SelectedKeywordSection from "./selected-keyword-section/SelectedKeywordSection"
+
+export type SelectedKeyword = {
+  keywordId: number
+  keywordName: string
+  keywordDivision: string
+}
+
+const ScentKeyword = () => {
+  const [selectedKeywords, setSelectedKeywords] = useState<SelectedKeyword[]>(
+    []
+  )
+
+  const handleToggleKeyword = (keyword: SelectedKeyword) => {
+    setSelectedKeywords((prev) => {
+      const isSelected = prev.some(
+        (selectedKeyword) => selectedKeyword.keywordId === keyword.keywordId
+      )
+
+      if (isSelected) {
+        return prev.filter(
+          (selectedKeyword) => selectedKeyword.keywordId !== keyword.keywordId
+        )
+      }
+
+      return [...prev, keyword]
+    })
+  }
+
+  const handleClearKeywords = () => {
+    setSelectedKeywords([])
+  }
+
+  return (
+    <Container className="px-30 pt-16 pb-40">
+      <Vstack>
+        <PageIntro
+          title="나만의 향 찾기"
+          description={`지금 가장 끌리는 무드를 선택해 보세요
+당신의 취향을 담은 향기를 큐레이션해 드립니다`}
+          backButton={<BackButton />}
+        />
+
+        <KeywordSelectionSection
+          selectedKeywords={selectedKeywords}
+          onToggleKeyword={handleToggleKeyword}
+        />
+
+        <SelectedKeywordSection
+          selectedKeywords={selectedKeywords}
+          onToggleKeyword={handleToggleKeyword}
+          onClearKeywords={handleClearKeywords}
+        />
+
+        <Button
+          size="lg"
+          className="mt-lg flex items-center justify-center text-lg font-bold"
+        >
+          나만의 향기 확인하기
+        </Button>
+      </Vstack>
+    </Container>
+  )
+}
+
+export default ScentKeyword

--- a/src/features/scent-keyword/page/keyword-selection-section/KeywordSelectionSection.tsx
+++ b/src/features/scent-keyword/page/keyword-selection-section/KeywordSelectionSection.tsx
@@ -1,0 +1,66 @@
+import { Tag } from "@/shared/components"
+import { scentKeywordMockData } from "../../data/scent-keyword-mock-data"
+import type { SelectedKeyword } from "../ScentKeyword"
+
+type KeywordSelectionSectionProps = {
+  selectedKeywords: SelectedKeyword[]
+  onToggleKeyword: (keyword: SelectedKeyword) => void
+}
+
+const KeywordSelectionSection = ({
+  selectedKeywords,
+  onToggleKeyword,
+}: KeywordSelectionSectionProps) => {
+  const isSelectedKeyword = (keywordId: number) => {
+    return selectedKeywords.some(
+      (selectedKeyword) => selectedKeyword.keywordId === keywordId
+    )
+  }
+
+  return (
+    <article className="pt-2xl">
+      <h3 className="pb-md text-md font-bold text-text-primary">
+        카테고리별 원하는 키워드를 선택해주세요
+      </h3>
+
+      <div>
+        {scentKeywordMockData.map((section) => {
+          return (
+            <section
+              key={section.keywordDivision}
+              className="flex flex-col gap-md pb-lg"
+            >
+              <h4 className="text-lg font-extrabold text-primary">
+                {section.title}
+              </h4>
+
+              <div className="flex flex-wrap gap-xs">
+                {section.keywords.map((keyword) => {
+                  const isSelected = isSelectedKeyword(keyword.keywordId)
+
+                  return (
+                    <Tag
+                      key={keyword.keywordId}
+                      size="sm"
+                      label={keyword.keywordName}
+                      variant={isSelected ? "selected" : "outlined"}
+                      onClick={() => {
+                        onToggleKeyword({
+                          keywordId: keyword.keywordId,
+                          keywordName: keyword.keywordName,
+                          keywordDivision: section.keywordDivision,
+                        })
+                      }}
+                    />
+                  )
+                })}
+              </div>
+            </section>
+          )
+        })}
+      </div>
+    </article>
+  )
+}
+
+export default KeywordSelectionSection

--- a/src/features/scent-keyword/page/selected-keyword-section/SelectedKeywordSection.tsx
+++ b/src/features/scent-keyword/page/selected-keyword-section/SelectedKeywordSection.tsx
@@ -1,0 +1,56 @@
+import { Tag } from "@/shared/components"
+import type { SelectedKeyword } from "../ScentKeyword"
+
+type SelectedKeywordSectionProps = {
+  selectedKeywords: SelectedKeyword[]
+  onToggleKeyword: (keyword: SelectedKeyword) => void
+  onClearKeywords: () => void
+}
+
+const SelectedKeywordSection = ({
+  selectedKeywords,
+  onToggleKeyword,
+  onClearKeywords,
+}: SelectedKeywordSectionProps) => {
+  const hasSelectedKeywords = selectedKeywords.length > 0
+
+  return (
+    <article className="w-full">
+      <div className="w-full rounded-lg border border-green-input bg-white p-lg">
+        <div className="flex justify-between pb-md text-text-sub">
+          <p>선택한 키워드를 바탕으로 향을 추천해드릴게요</p>
+
+          {hasSelectedKeywords && (
+            <button
+              type="button"
+              onClick={onClearKeywords}
+              className="text-sm transition-colors hover:cursor-pointer hover:text-text-primary"
+            >
+              All Clear
+            </button>
+          )}
+        </div>
+
+        {hasSelectedKeywords && (
+          <div className="flex flex-wrap gap-sm">
+            {selectedKeywords.map((keyword) => {
+              return (
+                <Tag
+                  key={keyword.keywordId}
+                  size="sm"
+                  label={keyword.keywordName}
+                  variant="selected"
+                  onClick={() => {
+                    onToggleKeyword(keyword)
+                  }}
+                />
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </article>
+  )
+}
+
+export default SelectedKeywordSection

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as WideRouteImport } from './routes/_wide'
 import { Route as WideIndexRouteImport } from './routes/_wide.index'
 import { Route as WideScentSurveyRouteImport } from './routes/_wide.scent-survey'
+import { Route as WideScentKeywordRouteImport } from './routes/_wide.scent-keyword'
 import { Route as WideNotRealRouteImport } from './routes/_wide.not-real'
 import { Route as WideMyPageRouteImport } from './routes/_wide.my-page'
 import { Route as WideFindScentRouteImport } from './routes/_wide.find-scent'
@@ -28,6 +29,11 @@ const WideIndexRoute = WideIndexRouteImport.update({
 const WideScentSurveyRoute = WideScentSurveyRouteImport.update({
   id: '/scent-survey',
   path: '/scent-survey',
+  getParentRoute: () => WideRoute,
+} as any)
+const WideScentKeywordRoute = WideScentKeywordRouteImport.update({
+  id: '/scent-keyword',
+  path: '/scent-keyword',
   getParentRoute: () => WideRoute,
 } as any)
 const WideNotRealRoute = WideNotRealRouteImport.update({
@@ -51,12 +57,14 @@ export interface FileRoutesByFullPath {
   '/find-scent': typeof WideFindScentRoute
   '/my-page': typeof WideMyPageRoute
   '/not-real': typeof WideNotRealRoute
+  '/scent-keyword': typeof WideScentKeywordRoute
   '/scent-survey': typeof WideScentSurveyRoute
 }
 export interface FileRoutesByTo {
   '/find-scent': typeof WideFindScentRoute
   '/my-page': typeof WideMyPageRoute
   '/not-real': typeof WideNotRealRoute
+  '/scent-keyword': typeof WideScentKeywordRoute
   '/scent-survey': typeof WideScentSurveyRoute
   '/': typeof WideIndexRoute
 }
@@ -66,20 +74,34 @@ export interface FileRoutesById {
   '/_wide/find-scent': typeof WideFindScentRoute
   '/_wide/my-page': typeof WideMyPageRoute
   '/_wide/not-real': typeof WideNotRealRoute
+  '/_wide/scent-keyword': typeof WideScentKeywordRoute
   '/_wide/scent-survey': typeof WideScentSurveyRoute
   '/_wide/': typeof WideIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/find-scent' | '/my-page' | '/not-real' | '/scent-survey'
+  fullPaths:
+    | '/'
+    | '/find-scent'
+    | '/my-page'
+    | '/not-real'
+    | '/scent-keyword'
+    | '/scent-survey'
   fileRoutesByTo: FileRoutesByTo
-  to: '/find-scent' | '/my-page' | '/not-real' | '/scent-survey' | '/'
+  to:
+    | '/find-scent'
+    | '/my-page'
+    | '/not-real'
+    | '/scent-keyword'
+    | '/scent-survey'
+    | '/'
   id:
     | '__root__'
     | '/_wide'
     | '/_wide/find-scent'
     | '/_wide/my-page'
     | '/_wide/not-real'
+    | '/_wide/scent-keyword'
     | '/_wide/scent-survey'
     | '/_wide/'
   fileRoutesById: FileRoutesById
@@ -111,6 +133,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WideScentSurveyRouteImport
       parentRoute: typeof WideRoute
     }
+    '/_wide/scent-keyword': {
+      id: '/_wide/scent-keyword'
+      path: '/scent-keyword'
+      fullPath: '/scent-keyword'
+      preLoaderRoute: typeof WideScentKeywordRouteImport
+      parentRoute: typeof WideRoute
+    }
     '/_wide/not-real': {
       id: '/_wide/not-real'
       path: '/not-real'
@@ -139,6 +168,7 @@ interface WideRouteChildren {
   WideFindScentRoute: typeof WideFindScentRoute
   WideMyPageRoute: typeof WideMyPageRoute
   WideNotRealRoute: typeof WideNotRealRoute
+  WideScentKeywordRoute: typeof WideScentKeywordRoute
   WideScentSurveyRoute: typeof WideScentSurveyRoute
   WideIndexRoute: typeof WideIndexRoute
 }
@@ -147,6 +177,7 @@ const WideRouteChildren: WideRouteChildren = {
   WideFindScentRoute: WideFindScentRoute,
   WideMyPageRoute: WideMyPageRoute,
   WideNotRealRoute: WideNotRealRoute,
+  WideScentKeywordRoute: WideScentKeywordRoute,
   WideScentSurveyRoute: WideScentSurveyRoute,
   WideIndexRoute: WideIndexRoute,
 }

--- a/src/routes/_wide.scent-keyword.tsx
+++ b/src/routes/_wide.scent-keyword.tsx
@@ -1,0 +1,6 @@
+import ScentKeyword from "@/features/scent-keyword/page/ScentKeyword"
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/_wide/scent-keyword")({
+  component: ScentKeyword,
+})

--- a/src/shared/components/tag/Tag.tsx
+++ b/src/shared/components/tag/Tag.tsx
@@ -12,7 +12,7 @@ type TagProps = {
 }
 
 const tagVariants = cva(
-  "inline-flex items-center justify-center rounded-full transition-colors",
+  "inline-flex items-center justify-center rounded-full transition-all duration-200 active:scale-95",
   {
     variants: {
       size: {
@@ -21,7 +21,8 @@ const tagVariants = cva(
       },
       variant: {
         outlined: "cursor-pointer border border-border text-text-sub bg-gray-0",
-        selected: "cursor-pointer bg-button text-text-button",
+        selected:
+          "cursor-pointer border border-border bg-button text-text-button",
         soft: "cursor-default bg-surface-container text-text-highlight",
         subtle:
           "cursor-default border border-border bg-surface-default text-text-sub",


### PR DESCRIPTION
- 향기 키워드로 찾기 페이지 UI 구현
- 카테고리별 키워드 선택 섹션 구현
- 선택된 키워드 표시 영역 구현
- 키워드 선택/해제 및 전체 해제 기능 반영
- 공통 Tag 컴포넌트 재사용 및 인터랙션 반영

## 🔗 관련 이슈

- closes #111

## 📸 스크린샷 (선택)
<img width="864" height="936" alt="GIF 2026-04-17 오후 7-14-46" src="https://github.com/user-attachments/assets/6d64a631-cf9d-4685-9e3f-437fcceb3902" />
샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인.
