### PR TITLE
refactor: api 함수 분리

### DIFF
--- a/src/features/my-page/api/user.api.ts
+++ b/src/features/my-page/api/user.api.ts
@@ -1,0 +1,31 @@
+import type { HistoryItem } from "../mocks/history.mock"
+import type { FavoriteScent, UserProfile } from "../types"
+
+const BASE_URL = import.meta.env.VITE_BASE_URL
+
+export const getMyProfile = async (): Promise<UserProfile> => {
+  const res = await fetch(`${BASE_URL}/accounts/me`)
+  if (!res.ok) {
+    console.log("BASE_URL", BASE_URL)
+    throw new Error("유저 정보 요청 실패")
+  }
+  return res.json()
+}
+
+export const getFavoriteScents = async (): Promise<FavoriteScent[]> => {
+  const res = await fetch(`${BASE_URL}/accounts/favorite-scents`)
+  if (!res.ok) {
+    console.log("BASE_URL", BASE_URL)
+    throw new Error("저장된 향기 요청 실패")
+  }
+  return res.json()
+}
+
+export const getHistoryList = async (): Promise<HistoryItem[]> => {
+  const res = await fetch(`${BASE_URL}/analyses/`)
+  if (!res.ok) {
+    console.log("BASE_URL", BASE_URL)
+    throw new Error("히스토리 요청 실패")
+  }
+  return res.json()
+}

--- a/src/features/my-page/api/user.api.ts
+++ b/src/features/my-page/api/user.api.ts
@@ -1,31 +1,18 @@
+import { instance } from "@/shared/api/axios-instance"
 import type { HistoryItem } from "../mocks/history.mock"
 import type { FavoriteScent, UserProfile } from "../types"
 
-const BASE_URL = import.meta.env.VITE_BASE_URL
-
 export const getMyProfile = async (): Promise<UserProfile> => {
-  const res = await fetch(`${BASE_URL}/accounts/me`)
-  if (!res.ok) {
-    console.log("BASE_URL", BASE_URL)
-    throw new Error("유저 정보 요청 실패")
-  }
-  return res.json()
+  const { data } = await instance.get("/accounts/me")
+  return data
 }
 
 export const getFavoriteScents = async (): Promise<FavoriteScent[]> => {
-  const res = await fetch(`${BASE_URL}/accounts/favorite-scents`)
-  if (!res.ok) {
-    console.log("BASE_URL", BASE_URL)
-    throw new Error("저장된 향기 요청 실패")
-  }
-  return res.json()
+  const { data } = await instance.get("/accounts/favorite-scents")
+  return data
 }
 
 export const getHistoryList = async (): Promise<HistoryItem[]> => {
-  const res = await fetch(`${BASE_URL}/analyses/`)
-  if (!res.ok) {
-    console.log("BASE_URL", BASE_URL)
-    throw new Error("히스토리 요청 실패")
-  }
-  return res.json()
+  const { data } = await instance.get("/analyses/")
+  return data
 }

--- a/src/features/my-page/hooks/useFavoriteScents.ts
+++ b/src/features/my-page/hooks/useFavoriteScents.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react"
+import { getFavoriteScents } from "../api/user.api"
+import type { FavoriteScent } from "../types"
+
+export const useFavoriteScents = () => {
+  const [favoriteScents, setFavoriteScents] = useState<FavoriteScent[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<unknown>(null)
+
+  useEffect(() => {
+    const fetchFavoriteScents = async () => {
+      try {
+        const data = await getFavoriteScents()
+        setFavoriteScents(data)
+      } catch (err) {
+        console.error("저장된 향기 가져오기 실패")
+        setError(err)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchFavoriteScents()
+  }, [])
+
+  return {
+    favoriteScents,
+    isLoading,
+    error,
+  }
+}

--- a/src/features/my-page/hooks/useFavoriteScents.ts
+++ b/src/features/my-page/hooks/useFavoriteScents.ts
@@ -1,31 +1,16 @@
-import { useEffect, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
 import { getFavoriteScents } from "../api/user.api"
 import type { FavoriteScent } from "../types"
 
 export const useFavoriteScents = () => {
-  const [favoriteScents, setFavoriteScents] = useState<FavoriteScent[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<unknown>(null)
-
-  useEffect(() => {
-    const fetchFavoriteScents = async () => {
-      try {
-        const data = await getFavoriteScents()
-        setFavoriteScents(data)
-      } catch (err) {
-        console.error("저장된 향기 가져오기 실패")
-        setError(err)
-      } finally {
-        setIsLoading(false)
-      }
-    }
-
-    fetchFavoriteScents()
-  }, [])
+  const query = useQuery<FavoriteScent[]>({
+    queryKey: ["favoriteScents"],
+    queryFn: getFavoriteScents,
+  })
 
   return {
-    favoriteScents,
-    isLoading,
-    error,
+    favoriteScents: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
   }
 }

--- a/src/features/my-page/hooks/useHistoryList.ts
+++ b/src/features/my-page/hooks/useHistoryList.ts
@@ -1,32 +1,10 @@
-import { useEffect, useState } from "react"
-
+import { useQuery } from "@tanstack/react-query"
 import { getHistoryList } from "../api/user.api"
 import type { HistoryItem } from "../mocks/history.mock"
 
 export const useHistoryList = () => {
-  const [historyList, setHistoryList] = useState<HistoryItem[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<unknown>(null)
-
-  useEffect(() => {
-    const fetchHistoryList = async () => {
-      try {
-        const data = await getHistoryList()
-        setHistoryList(data)
-      } catch (err) {
-        console.error("기록 불러오기 실패")
-        setError(err)
-      } finally {
-        setIsLoading(false)
-      }
-    }
-
-    fetchHistoryList()
-  }, [])
-
-  return {
-    historyList,
-    isLoading,
-    error,
-  }
+  return useQuery<HistoryItem[]>({
+    queryKey: ["my-page", "historyList"],
+    queryFn: getHistoryList,
+  })
 }

--- a/src/features/my-page/hooks/useHistoryList.ts
+++ b/src/features/my-page/hooks/useHistoryList.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react"
+
+import { getHistoryList } from "../api/user.api"
+import type { HistoryItem } from "../mocks/history.mock"
+
+export const useHistoryList = () => {
+  const [historyList, setHistoryList] = useState<HistoryItem[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<unknown>(null)
+
+  useEffect(() => {
+    const fetchHistoryList = async () => {
+      try {
+        const data = await getHistoryList()
+        setHistoryList(data)
+      } catch (err) {
+        console.error("기록 불러오기 실패")
+        setError(err)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchHistoryList()
+  }, [])
+
+  return {
+    historyList,
+    isLoading,
+    error,
+  }
+}

--- a/src/features/my-page/hooks/useUserProfile.ts
+++ b/src/features/my-page/hooks/useUserProfile.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react"
+import { getMyProfile } from "../api/user.api"
+import type { UserProfile } from "../types"
+
+export const useUserProfile = () => {
+  const [user, setUser] = useState<UserProfile | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<unknown>(null)
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const data = await getMyProfile()
+        setUser(data)
+      } catch (err) {
+        setError(err)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchUser()
+  }, [])
+
+  return { user, isLoading, error }
+}

--- a/src/features/my-page/hooks/useUserProfile.ts
+++ b/src/features/my-page/hooks/useUserProfile.ts
@@ -1,26 +1,10 @@
-import { useEffect, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
 import { getMyProfile } from "../api/user.api"
 import type { UserProfile } from "../types"
 
 export const useUserProfile = () => {
-  const [user, setUser] = useState<UserProfile | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<unknown>(null)
-
-  useEffect(() => {
-    const fetchUser = async () => {
-      try {
-        const data = await getMyProfile()
-        setUser(data)
-      } catch (err) {
-        setError(err)
-      } finally {
-        setIsLoading(false)
-      }
-    }
-
-    fetchUser()
-  }, [])
-
-  return { user, isLoading, error }
+  return useQuery<UserProfile>({
+    queryKey: ["my-page", "userProfile"],
+    queryFn: getMyProfile,
+  })
 }

--- a/src/features/my-page/mocks/handlers.ts
+++ b/src/features/my-page/mocks/handlers.ts
@@ -4,16 +4,18 @@ import { mockFavoriteScents } from "./favoriteScents.mock"
 import { mockHistoryList } from "./history.mock"
 import { mockUserProfile } from "./myPage.mock"
 
+const BASE_URL = import.meta.env.VITE_BASE_URL
+
 export const myPageHandlers = [
-  http.get("api/v1/accounts/me", () => {
+  http.get(`${BASE_URL}/accounts/me`, () => {
     return HttpResponse.json(mockUserProfile)
   }),
 
-  http.get("api/v1/accounts/favorite-scents", () => {
+  http.get(`${BASE_URL}/accounts/favorite-scents`, () => {
     return HttpResponse.json(mockFavoriteScents)
   }),
 
-  http.get("api/v1/analyses/", () => {
+  http.get(`${BASE_URL}/analyses/`, () => {
     return HttpResponse.json(mockHistoryList)
   }),
 ]

--- a/src/features/my-page/mocks/history.mock.ts
+++ b/src/features/my-page/mocks/history.mock.ts
@@ -1,10 +1,14 @@
-import type { HistoryCardProps } from "@/features/my-page/types"
-
-type MockHistoryItem = HistoryCardProps & {
+export type HistoryItem = {
   id: number
+  imageSrc?: string
+  imageAlt?: string
+  title: string
+  badgeText?: string
+  tags: string[]
+  date: string
 }
 
-export const mockHistoryList: MockHistoryItem[] = [
+export const mockHistoryList: HistoryItem[] = [
   {
     id: 1,
     imageSrc: "/images/sample-perfume.png",
@@ -13,9 +17,6 @@ export const mockHistoryList: MockHistoryItem[] = [
     badgeText: "챗봇 추천",
     tags: ["샌달우드", "베르가못"],
     date: "2026. 04. 12",
-    onClick: () => {
-      console.log("Golden Amber clicked")
-    },
   },
   {
     id: 2,
@@ -25,9 +26,6 @@ export const mockHistoryList: MockHistoryItem[] = [
     badgeText: "오늘의 추천",
     tags: ["장미", "화이트 머스크"],
     date: "2026. 04. 10",
-    onClick: () => {
-      console.log("Rose Garden clicked")
-    },
   },
   {
     id: 3,
@@ -37,8 +35,5 @@ export const mockHistoryList: MockHistoryItem[] = [
     badgeText: "챗봇 추천",
     tags: ["레몬", "머스크"],
     date: "2026. 04. 08",
-    onClick: () => {
-      console.log("Fresh Lemon clicked")
-    },
   },
 ]

--- a/src/features/my-page/pages/MyPage.tsx
+++ b/src/features/my-page/pages/MyPage.tsx
@@ -1,43 +1,23 @@
-import { CenterContainer, Container, FullScreen } from "@/shared/components"
-
-import { useEffect, useState } from "react"
-
-import type { UserProfile } from "../types"
-import UserSection from "./user-section/UserSection"
-// index 필요
+import { CenterContainer, Container } from "@/shared/components"
 import LoadingState from "@/shared/components/loading-state/LoadingState"
+import { useUserProfile } from "../hooks/useUserProfile"
 import TabSection from "./tab-section/TabSection"
+import UserSection from "./user-section/UserSection"
 
 export default function MyPage() {
-  const [user, setUser] = useState<UserProfile | null>(null)
-
-  useEffect(() => {
-    const fetchUser = async () => {
-      try {
-        const res = await fetch("/api/v1/accounts/me")
-        const data = await res.json()
-        setUser(data)
-      } catch {
-        console.error("유저 정보 가져오기 실패")
-      }
-    }
-
-    fetchUser()
-  }, [])
+  const { user, isLoading } = useUserProfile()
 
   return (
-    <FullScreen className="bg-surface-default">
-      <CenterContainer className="w-full py-2xl">
-        <Container
-          width="xl"
-          isPadded
-          className="min-h-screen max-w-container-xl bg-surface-default"
-        >
-          {/* 내부 영역 */}
-          {!user ? <LoadingState /> : <UserSection user={user} />}
-          <TabSection />
-        </Container>
-      </CenterContainer>
-    </FullScreen>
+    <CenterContainer className="min-h-screen w-full py-2xl">
+      <Container
+        width="xl"
+        isPadded
+        className="min-h-screen max-w-container-xl bg-surface-default"
+      >
+        {isLoading || !user ? <LoadingState /> : <UserSection user={user} />}
+
+        <TabSection />
+      </Container>
+    </CenterContainer>
   )
 }

--- a/src/features/my-page/pages/MyPage.tsx
+++ b/src/features/my-page/pages/MyPage.tsx
@@ -5,7 +5,7 @@ import TabSection from "./tab-section/TabSection"
 import UserSection from "./user-section/UserSection"
 
 export default function MyPage() {
-  const { user, isLoading } = useUserProfile()
+  const { data: user, isLoading, error } = useUserProfile()
 
   return (
     <CenterContainer className="min-h-screen w-full py-2xl">
@@ -14,7 +14,9 @@ export default function MyPage() {
         isPadded
         className="min-h-screen max-w-container-xl bg-surface-default"
       >
-        {isLoading || !user ? <LoadingState /> : <UserSection user={user} />}
+        {isLoading ? <LoadingState /> : null}
+        {!isLoading && error ? <div>유저 정보를 불러오지 못했어요.</div> : null}
+        {!isLoading && !error && user ? <UserSection user={user} /> : null}
 
         <TabSection />
       </Container>

--- a/src/features/my-page/pages/sections/collection-section/CollectionSection.tsx
+++ b/src/features/my-page/pages/sections/collection-section/CollectionSection.tsx
@@ -1,21 +1,28 @@
 import EmptyStateImage from "@/assets/images/empty-state/empty-scent.svg"
-import { mockFavoriteScents } from "@/features/my-page/mocks/favoriteScents.mock"
 import { EmptyState } from "@/shared/components"
+import LoadingState from "@/shared/components/loading-state/LoadingState"
+import { useFavoriteScents } from "../../../hooks/useFavoriteScents"
 import CollectionCard from "./collection-card/CollectionCard"
 
 export default function CollectionSection() {
-  const hasItems = mockFavoriteScents.length > 0
-  const collectionList = mockFavoriteScents.map((item) => ({
+  const { favoriteScents, isLoading } = useFavoriteScents()
+
+  const hasItems = favoriteScents.length > 0
+  const collectionList = favoriteScents.map((item) => ({
     ...item,
     date: item.savedAt,
   }))
 
+  if (isLoading) {
+    return <LoadingState />
+  }
+
   return (
     <section>
       <h2 className="px-md text-center text-lg font-bold text-text-primary">
-        저장된 향기{" "}
+        저장된 향기
         <span className="font-extrabold text-text-highlight">
-          {mockFavoriteScents.length}
+          {favoriteScents.length}
         </span>
         개
       </h2>

--- a/src/features/my-page/pages/sections/collection-section/CollectionSection.tsx
+++ b/src/features/my-page/pages/sections/collection-section/CollectionSection.tsx
@@ -5,7 +5,7 @@ import { useFavoriteScents } from "../../../hooks/useFavoriteScents"
 import CollectionCard from "./collection-card/CollectionCard"
 
 export default function CollectionSection() {
-  const { favoriteScents, isLoading } = useFavoriteScents()
+  const { error, favoriteScents, isLoading } = useFavoriteScents()
 
   const hasItems = favoriteScents.length > 0
   const collectionList = favoriteScents.map((item) => ({
@@ -15,6 +15,9 @@ export default function CollectionSection() {
 
   if (isLoading) {
     return <LoadingState />
+  }
+  if (error) {
+    return <div>저장된 향기를 불러오지 못했어요.</div>
   }
 
   return (

--- a/src/features/my-page/pages/sections/history-section/HistorySection.tsx
+++ b/src/features/my-page/pages/sections/history-section/HistorySection.tsx
@@ -5,11 +5,14 @@ import { useHistoryList } from "@/features/my-page/hooks/useHistoryList"
 import HistoryCard from "./history-card/HistoryCard"
 
 export default function HistorySection() {
-  const { historyList, isLoading } = useHistoryList()
+  const { data: historyList = [], isLoading, error } = useHistoryList()
   const hasItems = historyList.length > 0
 
   if (isLoading) {
     return <LoadingState />
+  }
+  if (error) {
+    return <div>기록을 불러오지 못했어요.</div>
   }
 
   return (

--- a/src/features/my-page/pages/sections/history-section/HistorySection.tsx
+++ b/src/features/my-page/pages/sections/history-section/HistorySection.tsx
@@ -1,25 +1,37 @@
-import { mockHistoryList } from "@/features/my-page/mocks/history.mock"
 import EmptyState from "@/shared/components/empty-state/EmptyState"
+import LoadingState from "@/shared/components/loading-state/LoadingState"
 
+import { useHistoryList } from "@/features/my-page/hooks/useHistoryList"
 import HistoryCard from "./history-card/HistoryCard"
 
 export default function HistorySection() {
-  const hasItems = mockHistoryList.length > 0
+  const { historyList, isLoading } = useHistoryList()
+  const hasItems = historyList.length > 0
+
+  if (isLoading) {
+    return <LoadingState />
+  }
 
   return (
     <section>
       <h2 className="px-md text-right text-md font-bold text-text-primary">
-        내 기록{" "}
+        내 기록
         <span className="font-extrabold text-primary">
-          {mockHistoryList.length}
+          {historyList.length}
         </span>
         개
       </h2>
 
       {hasItems ? (
         <div className="mt-md flex flex-col gap-md">
-          {mockHistoryList.map((item) => (
-            <HistoryCard key={item.id} {...item} />
+          {historyList.map((item) => (
+            <HistoryCard
+              key={item.id}
+              {...item}
+              onClick={() => {
+                console.log(`${item.title} clicked`)
+              }}
+            />
           ))}
         </div>
       ) : (

--- a/src/features/my-page/pages/sections/review-section/ReviewSection.tsx
+++ b/src/features/my-page/pages/sections/review-section/ReviewSection.tsx
@@ -2,10 +2,20 @@ import EmptyStateImage from "@/assets/images/empty-state/empty-scent.svg"
 import { mockReviewList } from "@/features/my-page/mocks/review.mock"
 import { EmptyState } from "@/shared/components"
 
+import { useHistoryList } from "@/features/my-page/hooks/useHistoryList"
+import LoadingState from "@/shared/components/loading-state/LoadingState"
 import ReviewCard from "./review-card/ReviewCard"
 
 export default function ReviewSection() {
   const hasItems = mockReviewList.length > 0
+  const { error, isLoading } = useHistoryList()
+
+  if (isLoading) {
+    return <LoadingState />
+  }
+  if (error) {
+    return <div>리뷰를 불러오지 못했어요.</div>
+  }
 
   return (
     <section>

--- a/src/features/my-page/types/user.type.ts
+++ b/src/features/my-page/types/user.type.ts
@@ -11,7 +11,7 @@ type UserProfile = {
 
 export type FavoriteScent = {
   id: number
-  imageSrc: string
+  imageSrc?: string
   imageAlt?: string
   category: string
   title: string


### PR DESCRIPTION
## 📌 작업 내용

- api 불러오는 함수를 api와 hook으로 분리했습니다.
- 이제 실제 api를 연결하더라도 api명을 따로 수정하지 않아도 됩니다.

## 🔗 관련 이슈

- closes #129

## 📸 스크린샷 (선택)
<img width="786" height="756" alt="image" src="https://github.com/user-attachments/assets/0b46d7e6-e50c-482e-84f4-edada4a6c837" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
