### PR TITLE
feat: 설문 질문 조회 API 연결

### DIFF
--- a/src/features/survey/api/survey-questions.types.ts
+++ b/src/features/survey/api/survey-questions.types.ts
@@ -1,0 +1,8 @@
+import { instance } from "@/shared/api/axios-instance"
+import type { SurveyQuestion } from "../types/survey.types"
+
+export const getSurveyQuestions = async () => {
+  const { data } = await instance.get<SurveyQuestion[]>("/question/survey")
+
+  return data
+}

--- a/src/features/survey/hooks/useSurveyQuestions.ts
+++ b/src/features/survey/hooks/useSurveyQuestions.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query"
+import { getSurveyQuestions } from "../api/survey-questions.types"
+
+export const useSurveyQuestions = () => {
+  return useQuery({
+    queryKey: ["survey-questions"],
+    queryFn: getSurveyQuestions,
+  })
+}

--- a/src/features/survey/page/ScentSurvey.tsx
+++ b/src/features/survey/page/ScentSurvey.tsx
@@ -1,22 +1,24 @@
+import EmptyScentImage from "@/assets/images/empty-state/empty-scent.svg"
 import {
   BackButton,
   Button,
   Container,
+  EmptyState,
   PageIntro,
   Vstack,
 } from "@/shared/components"
 import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
-import { scentSurveyMockData } from "../mocks/scent-servey-mock"
+import { useSurveyQuestions } from "../hooks/useSurveyQuestions"
 import PreferenceSlider from "./preference-slider/PreferenceSlider"
 
 const DEFAULT_SURVEY_VALUE = 2
 
 const ScentSurvey = () => {
+  const { data: questions, isPending, isError } = useSurveyQuestions()
+
   const navigate = useNavigate()
-  const [answers, setAnswers] = useState<number[]>(
-    scentSurveyMockData.map(() => DEFAULT_SURVEY_VALUE)
-  )
+  const [answers, setAnswers] = useState<Record<number, number>>({})
 
   const handleBack = () => {
     navigate({ to: "/find-scent" })
@@ -29,19 +31,36 @@ const ScentSurvey = () => {
     index: number
     value: number
   }) => {
-    setAnswers((prev) =>
-      prev.map((item, itemIndex) => {
-        if (itemIndex === index) {
-          return value
-        }
-
-        return item
-      })
-    )
+    setAnswers((prev) => ({
+      ...prev,
+      [index]: value,
+    }))
   }
 
   const handleSubmit = () => {
-    console.log(answers)
+    if (!questions) {
+      return
+    }
+
+    const normalizedAnswers = questions.map((_, index) => {
+      return answers[index] ?? DEFAULT_SURVEY_VALUE
+    })
+
+    console.log(normalizedAnswers)
+  }
+
+  if (isPending) {
+    return <Container className="px-30 pt-16 pb-40">불러오는 중...</Container>
+  }
+
+  if (isError || !questions) {
+    return (
+      <EmptyState
+        imageSrc={EmptyScentImage}
+        title="설문을 불러오지 못했습니다"
+        description="잠시 후 다시 시도해주세요!"
+      />
+    )
   }
 
   return (
@@ -54,15 +73,19 @@ const ScentSurvey = () => {
           backButton={<BackButton onClick={handleBack} />}
         />
 
-        {scentSurveyMockData.map((item, index) => (
-          <PreferenceSlider
-            item={item}
-            value={answers[index]}
-            onChange={(value) => {
-              handleChangeAnswer({ index, value })
-            }}
-          />
-        ))}
+        {questions.map((item, index) => {
+          return (
+            <PreferenceSlider
+              key={`${item.title}-${index}`}
+              item={item}
+              order={index + 1}
+              value={answers[index] ?? DEFAULT_SURVEY_VALUE}
+              onChange={(value) => {
+                handleChangeAnswer({ index, value })
+              }}
+            />
+          )
+        })}
 
         <Button
           size="lg"

--- a/src/features/survey/page/preference-slider/PreferenceSlider.stories.tsx
+++ b/src/features/survey/page/preference-slider/PreferenceSlider.stories.tsx
@@ -20,6 +20,12 @@ const meta = {
     item: {
       control: "object",
     },
+    order: {
+      control: {
+        type: "number",
+        min: 1,
+      },
+    },
     value: {
       control: {
         type: "range",
@@ -43,20 +49,32 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
+    order: 1,
     item: {
-      order: 1,
       title: "아침에 선호하는 향",
-      description: "하루를 시작할 때 어떤 느낌의 향을 원하시나요?",
-      labels: [
-        "매우 상쾌함",
-        "약간 상쾌함",
-        "보통",
-        "약간 포근함",
-        "매우 포근함",
+      additional: "하루를 시작할 때 어떤 느낌의 향을 원하시나요?",
+      left_label: "상쾌한",
+      right_label: "포근한",
+      answer: [
+        {
+          content: "매우 상쾌함",
+        },
+        {
+          content: "약간 상쾌함",
+        },
+        {
+          content: "보통",
+        },
+        {
+          content: "약간 포근함",
+        },
+        {
+          content: "매우 포근함",
+        },
       ],
-      edgeLabels: ["상쾌한", "포근한"],
     },
     value: 2,
+    onChange: () => {},
   },
   render: function Render(args) {
     const [{ value }, updateArgs] = useArgs()

--- a/src/features/survey/page/preference-slider/PreferenceSlider.tsx
+++ b/src/features/survey/page/preference-slider/PreferenceSlider.tsx
@@ -1,41 +1,33 @@
 import clsx from "clsx"
+import type { SurveyQuestion } from "../../types/survey.types"
 import "./preference-slider.css"
 
-type PreferenceSliderItem = {
-  order: number
-  title: string
-  description: string
-  labels: [string, string, string, string, string]
-  edgeLabels?: [string, string]
-}
-
 type PreferenceSliderProps = {
-  item: PreferenceSliderItem
+  item: SurveyQuestion
+  order: number
   value: number
-  onChange?: (value: number) => void
+  onChange: (value: number) => void
   className?: string
 }
 
-const POINTS = [0, 1, 2, 3, 4] as const
+const POINTS = [0, 1, 2, 3] as const
 const LAST_POINT_INDEX = POINTS.length - 1
 
 const PreferenceSlider = ({
   item,
+  order,
   value,
   onChange,
   className,
 }: PreferenceSliderProps) => {
-  const { order, title, description, labels, edgeLabels } = item
+  const { title, additional, left_label, right_label, answer } = item
 
+  const labels = answer.map(({ content }) => content)
   const percentage = (value / LAST_POINT_INDEX) * 100
   const selectedLabel = labels[value]
-  const [leftEdgeLabel, rightEdgeLabel] = edgeLabels ?? [labels[0], labels[4]]
+  const [leftEdgeLabel, rightEdgeLabel] = [left_label, right_label]
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (!onChange) {
-      return
-    }
-
     onChange(Number(event.target.value))
   }
 
@@ -53,7 +45,7 @@ const PreferenceSlider = ({
 
         <div className="flex flex-col">
           <h3 className="text-lg font-bold text-text-primary">{title}</h3>
-          <p className="text-md text-text-sub">{description}</p>
+          <p className="text-md text-text-sub">{additional}</p>
         </div>
       </header>
 
@@ -94,10 +86,6 @@ const PreferenceSlider = ({
                 className="absolute top-1/2 z-30 h-xl w-xl -translate-x-1/2 -translate-y-1/2 rounded-full"
                 style={{ left: pointLeft }}
                 onClick={() => {
-                  if (!onChange) {
-                    return
-                  }
-
                   onChange(point)
                 }}
               />

--- a/src/features/survey/types/survey.types.ts
+++ b/src/features/survey/types/survey.types.ts
@@ -1,0 +1,11 @@
+export type SurveyAnswerItem = {
+  content: string
+}
+
+export type SurveyQuestion = {
+  title: string
+  additional: string
+  left_label: string
+  right_label: string
+  answer: SurveyAnswerItem[]
+}


### PR DESCRIPTION
## 📌 작업 내용

- 설문 질문 조회 API 연결
- `useSurveyQuestions` 훅 추가
- 설문 페이지에서 mock 데이터 대신 조회 데이터 사용하도록 변경
- `PreferenceSlider`가 설문 조회 응답 구조를 사용하도록 수정

## 🔗 관련 이슈
백엔드 현재 4개 나오는 항목들 5개로 수정 예정
- closes #170 

## 📸 스크린샷 (선택)
<img width="921" height="876" alt="image" src="https://github.com/user-attachments/assets/652c6404-436c-4120-9192-d791558c332e" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인.