### PR TITLE
feat: 키워드 설문 questions api 연결

### DIFF
--- a/src/features/keyword/api/keyword-questions.api.ts
+++ b/src/features/keyword/api/keyword-questions.api.ts
@@ -1,0 +1,8 @@
+import { instance } from "@/shared/api/axios-instance"
+import type { KeywordQuestion } from "../types/keyword-questions.types"
+
+export const getKeywordQuestions = async () => {
+  const { data } = await instance.get<KeywordQuestion[]>("question/keyword")
+
+  return data
+}

--- a/src/features/keyword/hooks/keyword-questions.ts
+++ b/src/features/keyword/hooks/keyword-questions.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query"
+import { getKeywordQuestions } from "../api/keyword-questions.api"
+
+export const useKeywordQuestions = () => {
+  return useQuery({
+    queryKey: ["keyword-questions"],
+    queryFn: getKeywordQuestions,
+  })
+}

--- a/src/features/keyword/page/ScentKeyword.tsx
+++ b/src/features/keyword/page/ScentKeyword.tsx
@@ -1,12 +1,16 @@
+import EmptyScentImage from "@/assets/images/empty-state/empty-scent.svg"
 import {
   BackButton,
   Button,
   Container,
+  EmptyState,
   PageIntro,
   Vstack,
 } from "@/shared/components"
+import LoadingState from "@/shared/components/loading-state/LoadingState"
 import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
+import { useKeywordQuestions } from "../hooks/keyword-questions"
 import KeywordSelectionSection from "./keyword-selection-section/KeywordSelectionSection"
 import SelectedKeywordSection from "./selected-keyword-section/SelectedKeywordSection"
 
@@ -18,6 +22,7 @@ export type SelectedKeyword = {
 
 const ScentKeyword = () => {
   const navigate = useNavigate()
+  const { data: questions, isPending, isError } = useKeywordQuestions()
   const [selectedKeywords, setSelectedKeywords] = useState<SelectedKeyword[]>(
     []
   )
@@ -41,8 +46,23 @@ const ScentKeyword = () => {
   const handleBack = () => {
     navigate({ to: "/find-scent" })
   }
+
   const handleClearKeywords = () => {
     setSelectedKeywords([])
+  }
+
+  if (isPending) {
+    return <LoadingState />
+  }
+
+  if (isError || !questions) {
+    return (
+      <EmptyState
+        imageSrc={EmptyScentImage}
+        title="설문을 불러오지 못했습니다"
+        description="잠시 후 다시 시도해주세요!"
+      />
+    )
   }
 
   return (
@@ -56,6 +76,7 @@ const ScentKeyword = () => {
         />
 
         <KeywordSelectionSection
+          questions={questions}
           selectedKeywords={selectedKeywords}
           onToggleKeyword={handleToggleKeyword}
         />

--- a/src/features/keyword/page/keyword-selection-section/KeywordSelectionSection.tsx
+++ b/src/features/keyword/page/keyword-selection-section/KeywordSelectionSection.tsx
@@ -1,16 +1,38 @@
 import { Tag } from "@/shared/components"
-import { scentKeywordMockData } from "../../mocks/scent-keyword-mock-data"
+import type { KeywordQuestion } from "../../types/keyword-questions.types"
 import type { SelectedKeyword } from "../ScentKeyword"
 
 type KeywordSelectionSectionProps = {
+  questions: KeywordQuestion[]
   selectedKeywords: SelectedKeyword[]
   onToggleKeyword: (keyword: SelectedKeyword) => void
 }
 
+const divisionTitleMap: Record<string, string> = {
+  Place: "공간",
+  MD: "무드",
+  Texture: "질감",
+  "Time & Season": "시간과 계절",
+  "Scent Notes": "향 노트",
+}
+
 const KeywordSelectionSection = ({
+  questions,
   selectedKeywords,
   onToggleKeyword,
 }: KeywordSelectionSectionProps) => {
+  const groupedQuestions = questions.reduce<Record<string, KeywordQuestion[]>>(
+    (acc, question) => {
+      if (!acc[question.keyword_division]) {
+        acc[question.keyword_division] = []
+      }
+
+      acc[question.keyword_division].push(question)
+      return acc
+    },
+    {}
+  )
+
   const isSelectedKeyword = (keywordId: number) => {
     return selectedKeywords.some(
       (selectedKeyword) => selectedKeyword.keywordId === keywordId
@@ -24,31 +46,28 @@ const KeywordSelectionSection = ({
       </h3>
 
       <div>
-        {scentKeywordMockData.map((section) => {
+        {Object.entries(groupedQuestions).map(([division, keywords]) => {
           return (
-            <section
-              key={section.keywordDivision}
-              className="flex flex-col gap-md pb-lg"
-            >
+            <section key={division} className="flex flex-col gap-md pb-lg">
               <h4 className="text-lg font-extrabold text-primary">
-                {section.title}
+                {divisionTitleMap[division] ?? division}
               </h4>
 
               <div className="flex flex-wrap gap-xs">
-                {section.keywords.map((keyword) => {
-                  const isSelected = isSelectedKeyword(keyword.keywordId)
+                {keywords.map((keyword) => {
+                  const isSelected = isSelectedKeyword(keyword.keyword_id)
 
                   return (
                     <Tag
-                      key={keyword.keywordId}
+                      key={keyword.keyword_id}
                       size="sm"
-                      label={keyword.keywordName}
+                      label={keyword.keyword_name}
                       variant={isSelected ? "selected" : "outlined"}
                       onClick={() => {
                         onToggleKeyword({
-                          keywordId: keyword.keywordId,
-                          keywordName: keyword.keywordName,
-                          keywordDivision: section.keywordDivision,
+                          keywordId: keyword.keyword_id,
+                          keywordName: keyword.keyword_name,
+                          keywordDivision: keyword.keyword_division,
                         })
                       }}
                     />

--- a/src/features/keyword/types/keyword-questions.types.ts
+++ b/src/features/keyword/types/keyword-questions.types.ts
@@ -1,0 +1,12 @@
+export type KeywordDivision =
+  | "Place"
+  | "MD"
+  | "Texture"
+  | "Time & Season"
+  | "Scent Notes"
+
+export type KeywordQuestion = {
+  keyword_id: number
+  keyword_division: KeywordDivision
+  keyword_name: string
+}

--- a/src/features/survey/page/ScentSurvey.tsx
+++ b/src/features/survey/page/ScentSurvey.tsx
@@ -7,6 +7,7 @@ import {
   PageIntro,
   Vstack,
 } from "@/shared/components"
+import LoadingState from "@/shared/components/loading-state/LoadingState"
 import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
 import { useSurveyQuestions } from "../hooks/useSurveyQuestions"
@@ -50,7 +51,7 @@ const ScentSurvey = () => {
   }
 
   if (isPending) {
-    return <Container className="px-30 pt-16 pb-40">불러오는 중...</Container>
+    return <LoadingState />
   }
 
   if (isError || !questions) {


### PR DESCRIPTION
## 📌 작업 내용

- 키워드 질문 조회 API 연결
- `getKeywordQuestions` API 함수 추가
- `useKeywordQuestions` 쿼리 훅 추가
- 키워드 페이지에서 mock 데이터 대신 조회 데이터 사용하도록 수정
- `KeywordSelectionSection`의 mock 의존 제거 및 division 기준 렌더링으로 변경
- 로딩 및 에러 상태 처리 추가

## 🔗 관련 이슈

- closes #174

## 📸 스크린샷 (선택)
<img width="823" height="860" alt="스크린샷 2026-04-23 154736" src="https://github.com/user-attachments/assets/87742f84-73a5-49e4-bf93-6ff00075d6b3" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인.