### PR TITLE
fix: 챗봇 결과카드api 연결

### DIFF
--- a/src/features/chat/api/scent-response-detail.api.ts
+++ b/src/features/chat/api/scent-response-detail.api.ts
@@ -1,0 +1,8 @@
+import { instance } from "@/shared/api/axios-instance"
+import type { GetScentDetailResponse } from "../types/message.types"
+
+export const getScentDetail = async (id: number) => {
+  const response = await instance.get<GetScentDetailResponse>(`scents/${id}`)
+
+  return response.data
+}

--- a/src/features/chat/page/ScentChat.tsx
+++ b/src/features/chat/page/ScentChat.tsx
@@ -69,7 +69,7 @@ const ScentChat = () => {
         message: trimmedText,
       })
 
-      const assistantMessages = handleChatResponse({
+      const assistantMessages = await handleChatResponse({
         responseData: response.data,
         baseId,
       })

--- a/src/features/chat/page/chat-list/recommendation-card/RecommendationCard.tsx
+++ b/src/features/chat/page/chat-list/recommendation-card/RecommendationCard.tsx
@@ -1,4 +1,5 @@
 import { Button, Hstack, RoundBox, Tag, Vstack } from "@/shared/components"
+import EmptyImage from "@/shared/components/empty-image/EmptyImage"
 import type { RecommendationCardData } from "../../../types/message.types"
 import RecommendationActionButton from "./recommendation-button/RecommendationActionButton"
 
@@ -12,18 +13,24 @@ const RecommendationCard = ({
   description,
   tags,
 }: RecommendationCardProps) => {
+  const hasImage = Boolean(imageSrc)
+
   return (
     <RoundBox
       className="message-enter w-full max-w-[440px] bg-white"
       padding="none"
     >
       <Vstack gap="none">
-        <div>
-          <img
-            className="h-60 w-full rounded-t-xl object-cover"
-            src={imageSrc}
-            alt={imageAlt}
-          />
+        <div className="h-60 w-full overflow-hidden rounded-t-xl flex items-center justify-center">
+          {hasImage ? (
+            <img
+              className="h-full w-full object-cover"
+              src={imageSrc}
+              alt={imageAlt}
+            />
+          ) : (
+            <EmptyImage />
+          )}
         </div>
 
         <section className="flex flex-col gap-sm p-lg">

--- a/src/features/chat/page/chat-list/recommendation-card/RecommendationCard.tsx
+++ b/src/features/chat/page/chat-list/recommendation-card/RecommendationCard.tsx
@@ -17,7 +17,7 @@ const RecommendationCard = ({
 
   return (
     <RoundBox
-      className="message-enter w-full max-w-[440px] bg-white"
+      className="ml-10 border border-border message-enter w-full max-w-[440px] bg-white"
       padding="none"
     >
       <Vstack gap="none">
@@ -49,7 +49,7 @@ const RecommendationCard = ({
           </ul>
 
           <div className="flex flex-col gap-md">
-            <Button className="w-full">자세히 보기</Button>
+            <Button className="w-full">추천 결과 자세히 보기</Button>
 
             <Hstack>
               <RecommendationActionButton>저장하기</RecommendationActionButton>

--- a/src/features/chat/types/message.types.ts
+++ b/src/features/chat/types/message.types.ts
@@ -31,3 +31,26 @@ export type RecommendationMessage = {
 }
 
 export type ChatMessage = TextMessage | TypingMessage | RecommendationMessage
+
+export type SendChatMessageResponse = {
+  status: "success"
+  data: {
+    reply: string
+    is_recommendation: boolean
+    recommendation_id: number
+    scent_id: number
+    source_type: "chatbot"
+  }
+}
+
+export type GetScentDetailResponse = {
+  status: "success"
+  data: {
+    id: number
+    name: string
+    eng_name: string
+    description: string
+    tags: string[]
+    thumbnail_url: string
+  }
+}

--- a/src/features/chat/utils/handle-chat-response.ts
+++ b/src/features/chat/utils/handle-chat-response.ts
@@ -1,31 +1,39 @@
-// chat/utils/handle-chat-response.ts
+import { getScentDetail } from "../api/scent-response-detail.api"
 import type { SendChatMessageResponse } from "../api/send-chat-message.api"
 import type { ChatMessage } from "../types/message.types"
-import { createAssistantTextMessage } from "./create-chat-message"
+import {
+  createAssistantTextMessage,
+  createRecommendationMessage,
+} from "./create-chat-message"
+import { toRecommendationCardData } from "./to-recommendation-card-data"
 
 type HandleChatResponseParams = {
   responseData: SendChatMessageResponse["data"]
   baseId: number
 }
 
-export const handleChatResponse = ({
+export const handleChatResponse = async ({
   responseData,
   baseId,
-}: HandleChatResponseParams): ChatMessage[] => {
-  const { reply, is_recommendation, recommendation_id, scent_id } = responseData
+}: HandleChatResponseParams): Promise<ChatMessage[]> => {
+  const { reply, is_recommendation, scent_id } = responseData
 
-  // TODO : 결과추천 API 나오면 연결
-  if (is_recommendation) {
-    console.log("추천 도달", {
-      recommendation_id,
-      scent_id,
-    })
+  const assistantTextMessage = createAssistantTextMessage({
+    id: baseId + 2,
+    text: reply,
+  })
+
+  if (!is_recommendation || scent_id === null) {
+    return [assistantTextMessage]
   }
 
-  return [
-    createAssistantTextMessage({
-      id: baseId + 2,
-      text: reply,
-    }),
-  ]
+  const scentResponse = await getScentDetail(scent_id)
+  const recommendationCardData = toRecommendationCardData(scentResponse.data)
+
+  const recommendationMessage = createRecommendationMessage({
+    id: baseId + 3,
+    data: recommendationCardData,
+  })
+
+  return [assistantTextMessage, recommendationMessage]
 }

--- a/src/features/chat/utils/to-recommendation-card-data.ts
+++ b/src/features/chat/utils/to-recommendation-card-data.ts
@@ -1,0 +1,16 @@
+import type {
+  GetScentDetailResponse,
+  RecommendationCardData,
+} from "../types/message.types"
+
+export const toRecommendationCardData = (
+  scent: GetScentDetailResponse["data"]
+): RecommendationCardData => ({
+  id: String(scent.id),
+  imageSrc: scent.thumbnail_url,
+  imageAlt: scent.name,
+  name: scent.name,
+  englishName: scent.eng_name,
+  description: scent.description,
+  tags: scent.tags,
+})


### PR DESCRIPTION
## 📌 작업 내용
- scent detail api가 없어서 못했던 '추천 결과카드' 연결을 했습니다

- 챗봇 메시지 전송 응답에 따라 추천 카드 메시지가 표시되도록 연결했습니다.
- 추천 응답일 경우 scent detail API를 추가 호출해 카드 데이터를 매핑하도록 구현했습니다.
- 채팅 메시지 타입에 recommendation 분기를 추가하고 렌더링 로직에 반영했습니다.
- typing 메시지 제거 후 답변 텍스트와 추천 카드를 순서대로 표시하도록 처리했습니다.

## 🔗 관련 이슈
- 현재 백엔드에 이미지가 없어서 일단 안나옵니다

- closes #177 

## 📸 스크린샷 (선택)
<img width="771" height="627" alt="image" src="https://github.com/user-attachments/assets/e779c5f0-34c1-4478-b83c-4b09f3c30008" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
