### PR TITLE
feat:  S3 프리싸인 URL 발급 API 연결

### DIFF
--- a/src/features/photo/api/presigned-url.api.ts
+++ b/src/features/photo/api/presigned-url.api.ts
@@ -1,0 +1,18 @@
+import { instance } from "@/shared/api/axios-instance"
+import type {
+  PostAnalysisUploadUrlRequest,
+  PostAnalysisUploadUrlResponse,
+} from "../types/mobile-photo-step.types"
+
+export const postAnalysisUploadUrl = async ({
+  file_name,
+}: PostAnalysisUploadUrlRequest) => {
+  const { data } = await instance.post<PostAnalysisUploadUrlResponse>(
+    "/analyses/upload-url",
+    {
+      file_name,
+    }
+  )
+
+  return data
+}

--- a/src/features/photo/hooks/usePostAnalysisUploadUrl.ts
+++ b/src/features/photo/hooks/usePostAnalysisUploadUrl.ts
@@ -1,0 +1,8 @@
+import { useMutation } from "@tanstack/react-query"
+import { postAnalysisUploadUrl } from "../api/presigned-url.api"
+
+export const usePostAnalysisUploadUrl = () => {
+  return useMutation({
+    mutationFn: postAnalysisUploadUrl,
+  })
+}

--- a/src/features/photo/page/ScentPhoto.tsx
+++ b/src/features/photo/page/ScentPhoto.tsx
@@ -5,8 +5,10 @@ import {
   PageIntro,
   Vstack,
 } from "@/shared/components"
+import LoadingState from "@/shared/components/loading-state/LoadingState"
 import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
+import { usePostAnalysisUploadUrl } from "../hooks/usePostAnalysisUploadUrl"
 import type { MobilePhotoStep } from "../types/mobile-photo-step.types"
 import PhotoTipsSection from "./photo-tips-section/PhotoTipsSection"
 import PhotoUploadSection from "./photo-upload-section/PhotoUploadSection"
@@ -14,17 +16,54 @@ import PhotoUploadSection from "./photo-upload-section/PhotoUploadSection"
 const ScentPhoto = () => {
   const [step, setStep] = useState<MobilePhotoStep>("select")
   const [previewUrl, setPreviewUrl] = useState("")
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
   const navigate = useNavigate()
+  const { mutateAsync: postAnalysisUploadUrl, isPending: isCreatingUploadUrl } =
+    usePostAnalysisUploadUrl()
 
-  const hasImage = Boolean(previewUrl)
+  const [isUploadingToS3, setIsUploadingToS3] = useState(false)
+
+  const isSubmitting = isCreatingUploadUrl || isUploadingToS3
+
+  const hasImage = Boolean(selectedFile)
   const isCameraStep = step === "camera"
 
   const handleBack = () => {
     navigate({ to: "/find-scent" })
   }
 
+  const handleAnalyzeImage = async () => {
+    if (!selectedFile) return
+
+    try {
+      const uploadUrlData = await postAnalysisUploadUrl({
+        file_name: selectedFile.name,
+      })
+      setIsUploadingToS3(true)
+
+      const uploadResponse = await fetch(uploadUrlData.presigned_url, {
+        method: "PUT",
+        headers: {
+          "Content-Type": selectedFile.type,
+        },
+        body: selectedFile,
+      })
+
+      if (!uploadResponse.ok) {
+        throw new Error("이미지 업로드에 실패했습니다.")
+      }
+
+      console.log(uploadUrlData.img_url)
+      console.log(uploadUrlData.key)
+      console.log(uploadUrlData.resource_id)
+    } finally {
+      setIsUploadingToS3(false)
+    }
+  }
+
   return (
     <Container className="px-10 pt-16 pb-20 md:px-30 md:pt-16 md:pb-40">
+      {isSubmitting && <LoadingState />}
       <Vstack className="gap-md md:gap-lg">
         <PageIntro
           title="사진을 분석하여 향기를 찾습니다"
@@ -37,10 +76,18 @@ const ScentPhoto = () => {
           previewUrl={previewUrl}
           setPreviewUrl={setPreviewUrl}
           onStepChange={setStep}
+          setSelectedFile={setSelectedFile}
         />
 
         {!isCameraStep && <PhotoTipsSection />}
-        {!isCameraStep && <Button disabled={!hasImage}>이미지 분석하기</Button>}
+        {!isCameraStep && (
+          <Button
+            disabled={!hasImage || isSubmitting}
+            onClick={handleAnalyzeImage}
+          >
+            이미지 분석하기
+          </Button>
+        )}
       </Vstack>
     </Container>
   )

--- a/src/features/photo/page/ScentPhoto.tsx
+++ b/src/features/photo/page/ScentPhoto.tsx
@@ -52,10 +52,6 @@ const ScentPhoto = () => {
       if (!uploadResponse.ok) {
         throw new Error("이미지 업로드에 실패했습니다.")
       }
-
-      console.log(uploadUrlData.img_url)
-      console.log(uploadUrlData.key)
-      console.log(uploadUrlData.resource_id)
     } finally {
       setIsUploadingToS3(false)
     }

--- a/src/features/photo/page/photo-upload-section/PhotoUploadSection.tsx
+++ b/src/features/photo/page/photo-upload-section/PhotoUploadSection.tsx
@@ -16,6 +16,7 @@ type PhotoUploadSectionProps = {
   previewUrl: string
   setPreviewUrl: Dispatch<SetStateAction<string>>
   onStepChange: Dispatch<SetStateAction<MobilePhotoStep>>
+  setSelectedFile: Dispatch<SetStateAction<File | null>>
 }
 
 const PhotoUploadSection = ({
@@ -23,6 +24,7 @@ const PhotoUploadSection = ({
   previewUrl,
   setPreviewUrl,
   onStepChange,
+  setSelectedFile,
 }: PhotoUploadSectionProps) => {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const objectUrlRef = useRef<string | null>(null)
@@ -56,14 +58,16 @@ const PhotoUploadSection = ({
     }
 
     const imageUrl = URL.createObjectURL(file)
+    setSelectedFile(file)
     updatePreviewUrl(imageUrl, true)
     onStepChange("preview")
 
     event.target.value = ""
   }
 
-  const handleCaptureImage = (imageUrl: string) => {
-    updatePreviewUrl(imageUrl)
+  const handleCaptureImage = (imageUrl: string, file: File) => {
+    setSelectedFile(file)
+    updatePreviewUrl(imageUrl, true)
     onStepChange("preview")
   }
 

--- a/src/features/photo/page/photo-upload-section/mobile-camera-content/MobileCameraContent.tsx
+++ b/src/features/photo/page/photo-upload-section/mobile-camera-content/MobileCameraContent.tsx
@@ -5,7 +5,7 @@ import CameraIconButton from "./camera-icon-button/CameraIconButton"
 type CameraFacingMode = "user" | "environment"
 
 type MobileCameraContentProps = {
-  onCapture: (imageUrl: string) => void
+  onCapture: (imageUrl: string, file: File) => void
   onClose: () => void
 }
 
@@ -96,8 +96,23 @@ const MobileCameraContent = ({
 
     context.drawImage(video, 0, 0, canvas.width, canvas.height)
 
-    const imageUrl = canvas.toDataURL("image/jpeg", 0.9)
-    onCapture(imageUrl)
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          return
+        }
+
+        const file = new File([blob], `analysis-image-${Date.now()}.jpg`, {
+          type: "image/jpeg",
+        })
+
+        const imageUrl = URL.createObjectURL(file)
+
+        onCapture(imageUrl, file)
+      },
+      "image/jpeg",
+      0.9
+    )
   }
 
   useEffect(() => {

--- a/src/features/photo/types/mobile-photo-step.types.ts
+++ b/src/features/photo/types/mobile-photo-step.types.ts
@@ -1,1 +1,12 @@
 export type MobilePhotoStep = "select" | "camera" | "preview"
+
+export type PostAnalysisUploadUrlRequest = {
+  file_name: string
+}
+
+export type PostAnalysisUploadUrlResponse = {
+  presigned_url: string
+  img_url: string
+  key: string
+  resource_id: number
+}


### PR DESCRIPTION
## 📌 작업 내용

- S3 프리싸인 URL 발급 API 연결
- 이미지 선택/촬영 파일을 업로드 플로우에서 사용할 수 있도록 selectedFile 상태 추가
- 발급받은 presigned_url로 S3 PUT 업로드 로직 추가
- 업로드 진행 중 LoadingState 표시 및 중복 클릭 방지 처리

## 🔗 관련 이슈

- closes #179

## 📸 스크린샷 (선택)
<img width="1583" height="742" alt="스크린샷 2026-04-24 120428" src="https://github.com/user-attachments/assets/9e46b435-5ab7-4f19-a334-d504eacb654e" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인