### PR TITLE
feat: 키워드 분석 결과 API 연결

### DIFF
--- a/src/features/keyword/api/keyword-questions.api.ts
+++ b/src/features/keyword/api/keyword-questions.api.ts
@@ -1,8 +1,23 @@
 import { instance } from "@/shared/api/axios-instance"
-import type { KeywordQuestion } from "../types/keyword-questions.types"
+import type {
+  KeywordQuestion,
+  PostKeywordResultRequest,
+  PostKeywordResultResponse,
+} from "../types/keyword-questions.types"
 
 export const getKeywordQuestions = async () => {
   const { data } = await instance.get<KeywordQuestion[]>("question/keyword")
+
+  return data
+}
+
+export const postKeywordResult = async (
+  requestBody: PostKeywordResultRequest
+) => {
+  const { data } = await instance.post<PostKeywordResultResponse>(
+    "/question/keyword",
+    requestBody
+  )
 
   return data
 }

--- a/src/features/keyword/hooks/keyword-questions.ts
+++ b/src/features/keyword/hooks/keyword-questions.ts
@@ -1,9 +1,18 @@
-import { useQuery } from "@tanstack/react-query"
-import { getKeywordQuestions } from "../api/keyword-questions.api"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import {
+  getKeywordQuestions,
+  postKeywordResult,
+} from "../api/keyword-questions.api"
 
 export const useKeywordQuestions = () => {
   return useQuery({
     queryKey: ["keyword-questions"],
     queryFn: getKeywordQuestions,
+  })
+}
+
+export const usePostKeywordResult = () => {
+  return useMutation({
+    mutationFn: postKeywordResult,
   })
 }

--- a/src/features/keyword/page/ScentKeyword.tsx
+++ b/src/features/keyword/page/ScentKeyword.tsx
@@ -10,15 +10,15 @@ import {
 import LoadingState from "@/shared/components/loading-state/LoadingState"
 import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
-import { useKeywordQuestions } from "../hooks/keyword-questions"
+import {
+  useKeywordQuestions,
+  usePostKeywordResult,
+} from "../hooks/keyword-questions"
+import type { SelectedKeyword } from "../types/keyword-questions.types"
 import KeywordSelectionSection from "./keyword-selection-section/KeywordSelectionSection"
 import SelectedKeywordSection from "./selected-keyword-section/SelectedKeywordSection"
 
-export type SelectedKeyword = {
-  keywordId: number
-  keywordName: string
-  keywordDivision: string
-}
+const MIN_KEYWORD_COUNT = 3
 
 const ScentKeyword = () => {
   const navigate = useNavigate()
@@ -26,6 +26,8 @@ const ScentKeyword = () => {
   const [selectedKeywords, setSelectedKeywords] = useState<SelectedKeyword[]>(
     []
   )
+  const { mutate: postKeywordResult, isPending: isPostKeywordResultPending } =
+    usePostKeywordResult()
 
   const handleToggleKeyword = (keyword: SelectedKeyword) => {
     setSelectedKeywords((prev) => {
@@ -51,7 +53,35 @@ const ScentKeyword = () => {
     setSelectedKeywords([])
   }
 
-  if (isPending) {
+  const handleSubmitKeyword = () => {
+    if (selectedKeywords.length < MIN_KEYWORD_COUNT) {
+      return
+    }
+
+    const requestBody = selectedKeywords.map((keyword) => {
+      return {
+        keyword_id: keyword.keywordId,
+        keyword_name: keyword.keywordName,
+      }
+    })
+
+    postKeywordResult(requestBody, {
+      onSuccess: (result) => {
+        sessionStorage.setItem("keywordAnalysisResult", JSON.stringify(result))
+
+        navigate({
+          to: "/find-scent/result/$resultId",
+          params: {
+            resultId: String(result.id),
+          },
+          search: {
+            type: "keyword",
+          },
+        })
+      },
+    })
+  }
+  if (isPending || isPostKeywordResultPending) {
     return <LoadingState />
   }
 
@@ -88,8 +118,13 @@ const ScentKeyword = () => {
         />
 
         <Button
+          onClick={handleSubmitKeyword}
           size="lg"
           className="mt-lg flex items-center justify-center text-lg font-bold"
+          disabled={
+            selectedKeywords.length < MIN_KEYWORD_COUNT ||
+            isPostKeywordResultPending
+          }
         >
           나만의 향기 확인하기
         </Button>

--- a/src/features/keyword/page/keyword-selection-section/KeywordSelectionSection.tsx
+++ b/src/features/keyword/page/keyword-selection-section/KeywordSelectionSection.tsx
@@ -1,6 +1,8 @@
 import { Tag } from "@/shared/components"
-import type { KeywordQuestion } from "../../types/keyword-questions.types"
-import type { SelectedKeyword } from "../ScentKeyword"
+import type {
+  KeywordQuestion,
+  SelectedKeyword,
+} from "../../types/keyword-questions.types"
 
 type KeywordSelectionSectionProps = {
   questions: KeywordQuestion[]

--- a/src/features/keyword/page/selected-keyword-section/SelectedKeywordSection.tsx
+++ b/src/features/keyword/page/selected-keyword-section/SelectedKeywordSection.tsx
@@ -1,5 +1,5 @@
 import { Tag } from "@/shared/components"
-import type { SelectedKeyword } from "../ScentKeyword"
+import type { SelectedKeyword } from "../../types/keyword-questions.types"
 
 type SelectedKeywordSectionProps = {
   selectedKeywords: SelectedKeyword[]
@@ -18,7 +18,7 @@ const SelectedKeywordSection = ({
     <article className="w-full">
       <div className="w-full rounded-lg border border-green-input bg-white p-lg">
         <div className="flex justify-between pb-md text-text-sub">
-          <p>선택한 키워드를 바탕으로 향을 추천해드릴게요</p>
+          <p>최소 3개의 키워드를 선택해주세요</p>
 
           {hasSelectedKeywords && (
             <button

--- a/src/features/keyword/types/keyword-questions.types.ts
+++ b/src/features/keyword/types/keyword-questions.types.ts
@@ -1,3 +1,5 @@
+import type { RecommendedScent } from "@/shared/types"
+
 export type KeywordDivision =
   | "Place"
   | "MD"
@@ -9,4 +11,24 @@ export type KeywordQuestion = {
   keyword_id: number
   keyword_division: KeywordDivision
   keyword_name: string
+}
+
+export type PostKeywordResultRequest = {
+  keyword_id: number
+  keyword_name: string
+}[]
+
+export type KeywordResult = {
+  id: number
+  recommended_scent: RecommendedScent
+  ai_comment: string
+  match_score: number
+}
+
+export type PostKeywordResultResponse = KeywordResult
+
+export type SelectedKeyword = {
+  keywordId: number
+  keywordName: string
+  keywordDivision: string
 }


### PR DESCRIPTION
PR 내용
## 📌 작업 내용

- 키워드 선택 결과 제출 API를 연결했습니다.
- 선택한 키워드를 서버 요청 바디 형식에 맞게 변환했습니다.
- 키워드 분석 결과 응답을 sessionStorage에 저장하도록 처리했습니다.
- 분석 결과 응답 id를 기반으로 결과 페이지로 이동하도록 연결했습니다.
- 결과 페이지 이동 시 `type=keyword` search params를 함께 전달했습니다.
- 키워드 최소 3개 이상 선택 시에만 제출 가능하도록 제한했습니다.

## 🔗 관련 이슈

- closes #203 

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인