### PR TITLE
feat: 챗봇 추천 결과 상세 페이지 연결

### DIFF
--- a/src/features/chat/api/chat-recommendation-result.api.ts
+++ b/src/features/chat/api/chat-recommendation-result.api.ts
@@ -1,0 +1,14 @@
+import { instance } from "@/shared/api/axios-instance"
+import type { ResultResponse } from "@/shared/types"
+import type { GetChatRecommendationResultRequest } from "../types/message.types"
+
+export const getChatRecommendationResult = async ({
+  sessionId,
+  recommendationId,
+}: GetChatRecommendationResultRequest) => {
+  const { data } = await instance.get<ResultResponse>(
+    `/chatbot/sessions/${sessionId}/recommendations/${recommendationId}`
+  )
+
+  return data.data
+}

--- a/src/features/chat/api/send-chat-message.api.ts
+++ b/src/features/chat/api/send-chat-message.api.ts
@@ -1,20 +1,8 @@
 import { instance } from "@/shared/api/axios-instance"
-
-export type SendChatMessagePayload = {
-  sessionId: number
-  message: string
-}
-
-export type SendChatMessageResponse = {
-  status: "success"
-  data: {
-    reply: string
-    is_recommendation: boolean
-    recommendation_id: number | null
-    scent_id: number | null
-    source_type: string
-  }
-}
+import type {
+  SendChatMessagePayload,
+  SendChatMessageResponse,
+} from "../types/message.types"
 
 export const sendChatMessage = async ({
   sessionId,

--- a/src/features/chat/hooks/useChatRecommendationResultQuery.ts
+++ b/src/features/chat/hooks/useChatRecommendationResultQuery.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query"
+import { getChatRecommendationResult } from "../api/chat-recommendation-result.api"
+
+type UseChatRecommendationResultQueryParams = {
+  sessionId: number
+  recommendationId: number
+  enabled?: boolean
+}
+
+export const useChatRecommendationResultQuery = ({
+  sessionId,
+  recommendationId,
+  enabled = true,
+}: UseChatRecommendationResultQueryParams) => {
+  return useQuery({
+    queryKey: ["chat-recommendation-result", sessionId, recommendationId],
+    queryFn: () =>
+      getChatRecommendationResult({
+        sessionId,
+        recommendationId,
+      }),
+    enabled,
+  })
+}

--- a/src/features/chat/mocks/mock-recommendation-cards.ts
+++ b/src/features/chat/mocks/mock-recommendation-cards.ts
@@ -5,7 +5,8 @@ export const mockAssistantText =
   "차분하고 우디한 무드에 어울리는 향을 추천드릴게요."
 
 export const mockRecommendation: RecommendationCardData = {
-  id: "scent-2",
+  recommendationId: 999,
+  sessionId: 999,
   imageSrc: ImageMock,
   imageAlt: "향수 추천 이미지",
   name: "포레스트 리저브",

--- a/src/features/chat/page/ScentChat.tsx
+++ b/src/features/chat/page/ScentChat.tsx
@@ -72,6 +72,7 @@ const ScentChat = () => {
       const assistantMessages = await handleChatResponse({
         responseData: response.data,
         baseId,
+        sessionId,
       })
 
       setChatMessages((prev) => [

--- a/src/features/chat/page/chat-list/recommendation-card/RecommendationCard.tsx
+++ b/src/features/chat/page/chat-list/recommendation-card/RecommendationCard.tsx
@@ -1,11 +1,14 @@
 import { Button, Hstack, RoundBox, Tag, Vstack } from "@/shared/components"
 import EmptyImage from "@/shared/components/empty-image/EmptyImage"
+import { useNavigate } from "@tanstack/react-router"
 import type { RecommendationCardData } from "../../../types/message.types"
 import RecommendationActionButton from "./recommendation-button/RecommendationActionButton"
 
 type RecommendationCardProps = RecommendationCardData
 
 const RecommendationCard = ({
+  recommendationId,
+  sessionId,
   imageSrc,
   imageAlt,
   name,
@@ -13,7 +16,21 @@ const RecommendationCard = ({
   description,
   tags,
 }: RecommendationCardProps) => {
+  const navigate = useNavigate()
   const hasImage = Boolean(imageSrc)
+
+  const handleClickDetail = () => {
+    navigate({
+      to: "/find-scent/result/$resultId",
+      params: {
+        resultId: String(recommendationId),
+      },
+      search: {
+        type: "chat",
+        sessionId,
+      },
+    })
+  }
 
   return (
     <RoundBox
@@ -49,7 +66,9 @@ const RecommendationCard = ({
           </ul>
 
           <div className="flex flex-col gap-md">
-            <Button className="w-full">추천 결과 자세히 보기</Button>
+            <Button className="w-full" onClick={handleClickDetail}>
+              추천 결과 자세히 보기
+            </Button>
 
             <Hstack>
               <RecommendationActionButton>저장하기</RecommendationActionButton>

--- a/src/features/chat/types/message.types.ts
+++ b/src/features/chat/types/message.types.ts
@@ -1,5 +1,10 @@
+import type { RecommendedScent } from "@/shared/types"
+
+export type MessageRole = "user" | "assistant"
+
 export type RecommendationCardData = {
-  id: string
+  recommendationId: number
+  sessionId: number
   imageSrc: string
   imageAlt: string
   name: string
@@ -7,8 +12,6 @@ export type RecommendationCardData = {
   description: string
   tags: string[]
 }
-
-export type MessageRole = "user" | "assistant"
 
 export type TextMessage = {
   id: number
@@ -32,17 +35,6 @@ export type RecommendationMessage = {
 
 export type ChatMessage = TextMessage | TypingMessage | RecommendationMessage
 
-export type SendChatMessageResponse = {
-  status: "success"
-  data: {
-    reply: string
-    is_recommendation: boolean
-    recommendation_id: number
-    scent_id: number
-    source_type: "chatbot"
-  }
-}
-
 export type GetScentDetailResponse = {
   status: "success"
   data: {
@@ -53,4 +45,40 @@ export type GetScentDetailResponse = {
     tags: string[]
     thumbnail_url: string
   }
+}
+
+export type SendChatMessagePayload = {
+  sessionId: number
+  message: string
+}
+
+export type SendChatMessageResponse = {
+  status: "success"
+  data: {
+    reply: string
+    is_recommendation: boolean
+    recommendation_id: number | null
+    scent_id: number | null
+    source_type: "chat"
+  }
+}
+
+export type GetChatRecommendationResultRequest = {
+  sessionId: number
+  recommendationId: number
+}
+
+export type ChatRecommendationResultResponse = {
+  status: "success"
+  data: ChatRecommendationResult
+}
+
+export type ChatRecommendationResult = {
+  id: number
+  recommended_scent: RecommendedScent
+  ai_comment: string
+  match_score: number
+  source_type: "chatbot"
+  is_saved: boolean
+  created_at: string
 }

--- a/src/features/chat/utils/handle-chat-response.ts
+++ b/src/features/chat/utils/handle-chat-response.ts
@@ -1,6 +1,8 @@
 import { getScentDetail } from "../api/scent-response-detail.api"
-import type { SendChatMessageResponse } from "../api/send-chat-message.api"
-import type { ChatMessage } from "../types/message.types"
+import type {
+  ChatMessage,
+  SendChatMessageResponse,
+} from "../types/message.types"
 import {
   createAssistantTextMessage,
   createRecommendationMessage,
@@ -10,25 +12,32 @@ import { toRecommendationCardData } from "./to-recommendation-card-data"
 type HandleChatResponseParams = {
   responseData: SendChatMessageResponse["data"]
   baseId: number
+  sessionId: number
 }
 
 export const handleChatResponse = async ({
   responseData,
   baseId,
+  sessionId,
 }: HandleChatResponseParams): Promise<ChatMessage[]> => {
-  const { reply, is_recommendation, scent_id } = responseData
+  const { reply, is_recommendation, recommendation_id, scent_id } = responseData
 
   const assistantTextMessage = createAssistantTextMessage({
     id: baseId + 2,
     text: reply,
   })
 
-  if (!is_recommendation || scent_id === null) {
+  if (!is_recommendation || scent_id === null || recommendation_id === null) {
     return [assistantTextMessage]
   }
 
   const scentResponse = await getScentDetail(scent_id)
-  const recommendationCardData = toRecommendationCardData(scentResponse.data)
+
+  const recommendationCardData = {
+    ...toRecommendationCardData(scentResponse.data),
+    recommendationId: recommendation_id,
+    sessionId,
+  }
 
   const recommendationMessage = createRecommendationMessage({
     id: baseId + 3,

--- a/src/features/chat/utils/to-recommendation-card-data.ts
+++ b/src/features/chat/utils/to-recommendation-card-data.ts
@@ -3,14 +3,20 @@ import type {
   RecommendationCardData,
 } from "../types/message.types"
 
+type RecommendationCardDisplayData = Omit<
+  RecommendationCardData,
+  "recommendationId" | "sessionId"
+>
+
 export const toRecommendationCardData = (
   scent: GetScentDetailResponse["data"]
-): RecommendationCardData => ({
-  id: String(scent.id),
-  imageSrc: scent.thumbnail_url,
-  imageAlt: scent.name,
-  name: scent.name,
-  englishName: scent.eng_name,
-  description: scent.description,
-  tags: scent.tags,
-})
+): RecommendationCardDisplayData => {
+  return {
+    imageSrc: scent.thumbnail_url,
+    imageAlt: scent.name,
+    name: scent.name,
+    englishName: scent.eng_name,
+    description: scent.description,
+    tags: scent.tags,
+  }
+}

--- a/src/features/photo/page/ScentPhoto.tsx
+++ b/src/features/photo/page/ScentPhoto.tsx
@@ -69,7 +69,7 @@ const ScentPhoto = () => {
           resultId: String(analysisResult.id),
         },
         search: {
-          type: "survey",
+          type: "image",
         },
       })
     } finally {

--- a/src/features/result/page/ResultPage.tsx
+++ b/src/features/result/page/ResultPage.tsx
@@ -1,13 +1,18 @@
+import EmptyScentImage from "@/assets/images/empty-state/empty-scent.svg"
+import { useChatRecommendationResultQuery } from "@/features/chat/hooks/useChatRecommendationResultQuery"
 import {
   BackButton,
   CenterContainer,
   Container,
+  EmptyState,
+  LoadingState,
   PageIntro,
   Vstack,
 } from "@/shared/components"
 
 import { useNavigate } from "@tanstack/react-router"
-import { useAnalysisResultQuery } from "../hooks/useAnalysisResultQuery"
+import { useMemo } from "react"
+import type { AnalysisResult } from "../types/analysis-result.types"
 import AISection from "./sections/ai-section/AISection"
 import BottomSection from "./sections/bottom-section/BottomSection"
 import TopCardSection from "./sections/card-section/TopCardSection"
@@ -15,25 +20,99 @@ import ScentSection from "./sections/scent-section/ScentSection"
 
 type ResultType = "image" | "survey" | "keyword" | "chat"
 
+const RESULT_STORAGE_KEY: Record<Exclude<ResultType, "chat">, string> = {
+  image: "imageAnalysisResult",
+  survey: "surveyAnalysisResult",
+  keyword: "keywordAnalysisResult",
+}
+
 type ResultPageProps = {
   resultId: string
   type: ResultType
+  sessionId?: number
 }
 
-const ResultPage = ({ resultId }: ResultPageProps) => {
+const ResultPage = ({ resultId, type, sessionId }: ResultPageProps) => {
   const navigate = useNavigate()
-  const { data: result, isLoading, isError } = useAnalysisResultQuery(resultId)
 
-  if (isLoading) {
-    return <div>분석 결과를 불러오는 중입니다.</div>
-  }
+  const numericResultId = Number(resultId)
+  const isChatResult = type === "chat"
 
-  if (isError || !result) {
-    return <div>분석 결과를 불러올 수 없습니다.</div>
-  }
+  const storedResult = useMemo(() => {
+    if (isChatResult) {
+      return undefined
+    }
+
+    const storageKey = RESULT_STORAGE_KEY[type]
+    const storedResult = sessionStorage.getItem(storageKey)
+
+    if (!storedResult) {
+      return undefined
+    }
+
+    const parsedResult = JSON.parse(storedResult) as AnalysisResult
+
+    if (String(parsedResult.id) !== resultId) {
+      return undefined
+    }
+
+    return parsedResult
+  }, [resultId, type, isChatResult])
+
+  const {
+    data: chatResult,
+    isLoading: isChatLoading,
+    isError: isChatError,
+  } = useChatRecommendationResultQuery({
+    sessionId: sessionId ?? 0,
+    recommendationId: numericResultId,
+    enabled:
+      isChatResult &&
+      sessionId !== undefined &&
+      Number.isFinite(numericResultId),
+  })
+
+  const result = (isChatResult ? chatResult : storedResult) as
+    | AnalysisResult
+    | undefined
+
+  const isLoading = isChatResult ? isChatLoading : false
+  const isError = isChatResult ? isChatError : false
 
   const handleBack = () => {
     navigate({ to: "/my-page" })
+  }
+
+  if (isLoading) {
+    return (
+      <CenterContainer className="w-full py-2xl">
+        <Container
+          width="xl"
+          isPadded
+          className="min-h-screen max-w-container-xl bg-surface-default"
+        >
+          <LoadingState message="추천 결과를 불러오는 중입니다." />
+        </Container>
+      </CenterContainer>
+    )
+  }
+
+  if (isError || !result) {
+    return (
+      <CenterContainer className="w-full py-2xl">
+        <Container
+          width="xl"
+          isPadded
+          className="min-h-screen max-w-container-xl bg-surface-default"
+        >
+          <EmptyState
+            imageSrc={EmptyScentImage}
+            title="추천 결과를 불러올 수 없습니다."
+            description="잠시 후 다시 시도하거나, 향기 추천을 다시 진행해주세요."
+          />
+        </Container>
+      </CenterContainer>
+    )
   }
 
   return (
@@ -51,10 +130,13 @@ const ResultPage = ({ resultId }: ResultPageProps) => {
           />
 
           <TopCardSection result={result} />
+
           <AISection aiComment={result.ai_comment} />
+
           {result.recommended_scent && (
             <ScentSection scent={result.recommended_scent} />
           )}
+
           <BottomSection
             resultId={result.id}
             similarScents={result.recommended_scent?.similar_scents ?? []}

--- a/src/routes/_wide.find-scent.result.$resultId.tsx
+++ b/src/routes/_wide.find-scent.result.$resultId.tsx
@@ -27,15 +27,27 @@ const normalizeSearchId = (value: unknown) => {
 
 const ResultRoute = () => {
   const { resultId } = Route.useParams()
-  const { type, sessionId } = Route.useSearch()
+  const search = Route.useSearch()
 
-  return <ResultPage resultId={resultId} type={type} sessionId={sessionId} />
+  return (
+    <ResultPage
+      resultId={resultId}
+      type={search.type}
+      sessionId={"sessionId" in search ? search.sessionId : undefined}
+    />
+  )
 }
 
 export const Route = createFileRoute("/_wide/find-scent/result/$resultId")({
   validateSearch: (search: Record<string, unknown>) => {
+    const type = isResultType(search.type) ? search.type : "image"
+
+    if (type !== "chat") {
+      return { type }
+    }
+
     return {
-      type: isResultType(search.type) ? search.type : "image",
+      type,
       sessionId: normalizeSearchId(search.sessionId),
     }
   },

--- a/src/routes/_wide.find-scent.result.$resultId.tsx
+++ b/src/routes/_wide.find-scent.result.$resultId.tsx
@@ -14,17 +14,29 @@ const isResultType = (value: unknown): value is ResultType => {
   )
 }
 
+const normalizeSearchId = (value: unknown) => {
+  if (typeof value !== "string" && typeof value !== "number") {
+    return undefined
+  }
+
+  const normalizedValue = String(value).replaceAll('"', "")
+  const numericValue = Number(normalizedValue)
+
+  return Number.isFinite(numericValue) ? numericValue : undefined
+}
+
 const ResultRoute = () => {
   const { resultId } = Route.useParams()
-  const { type } = Route.useSearch()
+  const { type, sessionId } = Route.useSearch()
 
-  return <ResultPage resultId={resultId} type={type} />
+  return <ResultPage resultId={resultId} type={type} sessionId={sessionId} />
 }
 
 export const Route = createFileRoute("/_wide/find-scent/result/$resultId")({
   validateSearch: (search: Record<string, unknown>) => {
     return {
       type: isResultType(search.type) ? search.type : "image",
+      sessionId: normalizeSearchId(search.sessionId),
     }
   },
   component: ResultRoute,

--- a/src/shared/types/result-types/result.type.ts
+++ b/src/shared/types/result-types/result.type.ts
@@ -56,6 +56,11 @@ export type RecommendedScent = {
   created_at: string
 }
 
-export type ResultResponse = {
+export type ResultData = {
   recommended_scent: RecommendedScent
+}
+
+export type ResultResponse = {
+  status?: "success"
+  data: ResultData
 }


### PR DESCRIPTION
## 📌 작업 내용

- 챗봇 추천 카드에서 결과 상세 페이지로 이동하도록 연결
- 챗봇 추천 결과 상세 API 연동
- 결과 페이지에서 chat 타입일 때 챗봇 결과 API를 사용하도록 분기
- 기존 이미지/설문/키워드 결과는 sessionStorage 기반 로직 유지
- 결과 페이지 로딩/에러 상태 공통 컴포넌트로 처리

## 🔗 관련 이슈

- closes #207

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인