### PR TITLE
feat: 챗봇 재추천 api 연결 

### DIFF
--- a/src/features/chat/api/retry-chat-recommendation.api.ts
+++ b/src/features/chat/api/retry-chat-recommendation.api.ts
@@ -1,0 +1,15 @@
+import { instance } from "@/shared/api/axios-instance"
+import type {
+  RetryChatRecommendationParams,
+  RetryChatRecommendationResponse,
+} from "../types/retry-chat.types"
+
+export const retryChatRecommendation = async ({
+  sessionId,
+}: RetryChatRecommendationParams) => {
+  const { data } = await instance.post<RetryChatRecommendationResponse>(
+    `/chatbot/sessions/${sessionId}/recommendations/retry`
+  )
+
+  return data
+}

--- a/src/features/chat/api/scent-response-detail.api.ts
+++ b/src/features/chat/api/scent-response-detail.api.ts
@@ -1,8 +1,14 @@
 import { instance } from "@/shared/api/axios-instance"
 import type { GetScentDetailResponse } from "../types/message.types"
 
-export const getScentDetail = async (id: number) => {
-  const response = await instance.get<GetScentDetailResponse>(`scents/${id}`)
+type GetScentDetailParams = {
+  scentId: number
+}
 
-  return response.data
+export const getScentDetail = async ({ scentId }: GetScentDetailParams) => {
+  const { data } = await instance.get<GetScentDetailResponse>(
+    `/scents/${scentId}`
+  )
+
+  return data
 }

--- a/src/features/chat/hooks/useRetryChatRecommendation.ts
+++ b/src/features/chat/hooks/useRetryChatRecommendation.ts
@@ -1,0 +1,8 @@
+import { useMutation } from "@tanstack/react-query"
+import { retryChatRecommendation } from "../api/retry-chat-recommendation.api"
+
+export const useRetryChatRecommendationMutation = () => {
+  return useMutation({
+    mutationFn: retryChatRecommendation,
+  })
+}

--- a/src/features/chat/page/ScentChat.tsx
+++ b/src/features/chat/page/ScentChat.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/shared/components"
 import { useEffect, useState } from "react"
 import { useCreateChatSession } from "../hooks/useCreateChatSession"
+import { useRetryChatRecommendationMutation } from "../hooks/useRetryChatRecommendation"
 import { useSendChatMessage } from "../hooks/useSendChatMessage"
 import { messages } from "../mocks/chat-mocks"
 import type { ChatMessage } from "../types/message.types"
@@ -15,6 +16,8 @@ import {
   createUserMessage,
 } from "../utils/create-chat-message"
 import { handleChatResponse } from "../utils/handle-chat-response"
+
+import { handleRetryChatResponse } from "../utils/handle-retry-chat"
 import ChatHeader from "./chat-header/ChatHeader"
 import ChatInput from "./chat-input/ChatInput"
 import ChatList from "./chat-list/ChatList"
@@ -25,6 +28,8 @@ const ScentChat = () => {
 
   const { mutateAsync: createSession } = useCreateChatSession()
   const { mutateAsync: sendMessageAsync } = useSendChatMessage()
+  const { mutateAsync: retryChatRecommendation, isPending: isRetrying } =
+    useRetryChatRecommendationMutation()
 
   useEffect(() => {
     if (sessionId) {
@@ -62,6 +67,7 @@ const ScentChat = () => {
     })
 
     setChatMessages((prev) => [...prev, userMessage, typingMessage])
+
     try {
       const response = await sendMessageAsync({
         sessionId,
@@ -92,6 +98,48 @@ const ScentChat = () => {
     }
   }
 
+  const handleRetryRecommendation = async () => {
+    if (!sessionId) {
+      return
+    }
+
+    const baseId = Date.now()
+
+    const typingMessage = createTypingMessage({
+      id: baseId,
+    })
+
+    setChatMessages((prev) => [...prev, typingMessage])
+
+    try {
+      const retryResponse = await retryChatRecommendation({
+        sessionId,
+      })
+
+      const retryMessages = await handleRetryChatResponse({
+        responseData: retryResponse.data,
+        baseId,
+      })
+
+      setChatMessages((prev) => [
+        ...prev.filter((message) => message.id !== typingMessage.id),
+        ...retryMessages,
+      ])
+    } catch (error) {
+      console.error(error)
+
+      const errorMessage = createAssistantTextMessage({
+        id: baseId + 1,
+        text: "다시 추천에 실패했어요. 잠시 후 다시 시도해주세요.",
+      })
+
+      setChatMessages((prev) => [
+        ...prev.filter((message) => message.id !== typingMessage.id),
+        errorMessage,
+      ])
+    }
+  }
+
   return (
     <Container>
       <CenterContainer className="p-16">
@@ -101,7 +149,11 @@ const ScentChat = () => {
         >
           <Vstack gap="none" className="h-full">
             <ChatHeader />
-            <ChatList messages={chatMessages} />
+            <ChatList
+              messages={chatMessages}
+              onRetryRecommendation={handleRetryRecommendation}
+              isRetrying={isRetrying}
+            />
             <ChatInput onSendMessage={handleSendMessage} />
           </Vstack>
         </RoundBox>

--- a/src/features/chat/page/chat-list/ChatList.tsx
+++ b/src/features/chat/page/chat-list/ChatList.tsx
@@ -4,9 +4,15 @@ import ChatItem from "./chat-item/ChatItem"
 
 type ChatListProps = {
   messages: ChatMessage[]
+  onRetryRecommendation: () => void
+  isRetrying: boolean
 }
 
-const ChatList = ({ messages }: ChatListProps) => {
+const ChatList = ({
+  messages,
+  onRetryRecommendation,
+  isRetrying,
+}: ChatListProps) => {
   const scrollRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
@@ -23,7 +29,12 @@ const ChatList = ({ messages }: ChatListProps) => {
       className="flex min-h-0 flex-1 flex-col gap-md overflow-y-auto bg-surface-default p-lg [scrollbar-gutter:stable]"
     >
       {messages.map((message) => (
-        <ChatItem key={message.id} message={message} />
+        <ChatItem
+          key={message.id}
+          message={message}
+          onRetryRecommendation={onRetryRecommendation}
+          isRetrying={isRetrying}
+        />
       ))}
     </section>
   )

--- a/src/features/chat/page/chat-list/chat-item/ChatItem.tsx
+++ b/src/features/chat/page/chat-list/chat-item/ChatItem.tsx
@@ -5,15 +5,30 @@ import TypingBubble from "../typing-bubble/TypingBubble"
 
 type ChatItemProps = {
   message: ChatMessage
+  onRetryRecommendation: () => void
+  isRetrying: boolean
 }
 
-const ChatItem = ({ message }: ChatItemProps) => {
-  if (message.type === "text")
+const ChatItem = ({
+  message,
+  onRetryRecommendation,
+  isRetrying,
+}: ChatItemProps) => {
+  if (message.type === "text") {
     return <MessageBubble role={message.role} text={message.text} />
+  }
 
-  if (message.type === "typing") return <TypingBubble />
+  if (message.type === "typing") {
+    return <TypingBubble />
+  }
 
-  return <RecommendationCard {...message.data} />
+  return (
+    <RecommendationCard
+      {...message.data}
+      onRetry={onRetryRecommendation}
+      isRetrying={isRetrying}
+    />
+  )
 }
 
 export default ChatItem

--- a/src/features/chat/page/chat-list/recommendation-card/RecommendationCard.tsx
+++ b/src/features/chat/page/chat-list/recommendation-card/RecommendationCard.tsx
@@ -4,7 +4,10 @@ import { useNavigate } from "@tanstack/react-router"
 import type { RecommendationCardData } from "../../../types/message.types"
 import RecommendationActionButton from "./recommendation-button/RecommendationActionButton"
 
-type RecommendationCardProps = RecommendationCardData
+type RecommendationCardProps = RecommendationCardData & {
+  onRetry: () => void
+  isRetrying: boolean
+}
 
 const RecommendationCard = ({
   recommendationId,
@@ -14,6 +17,8 @@ const RecommendationCard = ({
   englishName,
   description,
   tags,
+  onRetry,
+  isRetrying,
 }: RecommendationCardProps) => {
   const navigate = useNavigate()
   const hasImage = Boolean(imageSrc)
@@ -70,7 +75,13 @@ const RecommendationCard = ({
 
             <Hstack>
               <RecommendationActionButton>저장하기</RecommendationActionButton>
-              <RecommendationActionButton>다시 추천</RecommendationActionButton>
+
+              <RecommendationActionButton
+                onClick={onRetry}
+                disabled={isRetrying}
+              >
+                {isRetrying ? "다시 추천 중..." : "다시 추천"}
+              </RecommendationActionButton>
             </Hstack>
           </div>
         </section>

--- a/src/features/chat/page/chat-list/recommendation-card/recommendation-button/RecommendationActionButton.tsx
+++ b/src/features/chat/page/chat-list/recommendation-card/recommendation-button/RecommendationActionButton.tsx
@@ -1,17 +1,19 @@
-type RecommendationActionButtonProps = {
-  children: React.ReactNode
-  onClick?: () => void
-}
+import type { ButtonHTMLAttributes, PropsWithChildren } from "react"
+
+type RecommendationActionButtonProps = PropsWithChildren<
+  ButtonHTMLAttributes<HTMLButtonElement>
+>
 
 const RecommendationActionButton = ({
   children,
-  onClick,
+  className = "",
+  ...props
 }: RecommendationActionButtonProps) => {
   return (
     <button
       type="button"
-      onClick={onClick}
-      className="h-8 w-full cursor-pointer rounded-md border border-border font-bold text-text-highlight hover:bg-green-input"
+      className={`h-8 w-full cursor-pointer rounded-md border border-border font-bold text-text-highlight hover:bg-green-input disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent ${className}`}
+      {...props}
     >
       {children}
     </button>

--- a/src/features/chat/types/retry-chat.types.ts
+++ b/src/features/chat/types/retry-chat.types.ts
@@ -1,0 +1,14 @@
+export type RetryChatRecommendationParams = {
+  sessionId: number
+}
+
+export type RetryChatRecommendationResponse = {
+  status: "success"
+  data: {
+    reply: string
+    recommendation_id: number
+    scent_id: number
+    retry_count: number
+    source_type: "chatbot"
+  }
+}

--- a/src/features/chat/utils/handle-retry-chat.ts
+++ b/src/features/chat/utils/handle-retry-chat.ts
@@ -1,33 +1,27 @@
 import { getScentDetail } from "../api/scent-response-detail.api"
-import type {
-  ChatMessage,
-  SendChatMessageResponse,
-} from "../types/message.types"
+import type { ChatMessage } from "../types/message.types"
+import type { RetryChatRecommendationResponse } from "../types/retry-chat.types"
 import {
   createAssistantTextMessage,
   createRecommendationMessage,
 } from "./create-chat-message"
 import { toRecommendationCardData } from "./to-recommendation-card-data"
 
-type HandleChatResponseParams = {
-  responseData: SendChatMessageResponse["data"]
+type HandleRetryChatResponseParams = {
+  responseData: RetryChatRecommendationResponse["data"]
   baseId: number
 }
 
-export const handleChatResponse = async ({
+export const handleRetryChatResponse = async ({
   responseData,
   baseId,
-}: HandleChatResponseParams): Promise<ChatMessage[]> => {
-  const { reply, is_recommendation, recommendation_id, scent_id } = responseData
+}: HandleRetryChatResponseParams): Promise<ChatMessage[]> => {
+  const { reply, recommendation_id, scent_id } = responseData
 
   const assistantTextMessage = createAssistantTextMessage({
-    id: baseId + 2,
+    id: baseId + 1,
     text: reply,
   })
-
-  if (!is_recommendation || scent_id == null || recommendation_id == null) {
-    return [assistantTextMessage]
-  }
 
   const scentResponse = await getScentDetail({
     scentId: scent_id,
@@ -39,7 +33,7 @@ export const handleChatResponse = async ({
   }
 
   const recommendationMessage = createRecommendationMessage({
-    id: baseId + 3,
+    id: baseId + 2,
     data: recommendationCardData,
   })
 


### PR DESCRIPTION
## 📌 작업 내용

- 챗봇 재추천 API 연동
- 추천 카드 `다시 추천` 버튼 이벤트 연결
- 재추천 응답 기반 AI 메시지 및 추천 카드 추가
- `scent_id` 기반 향 상세 조회 후 카드 데이터 매핑
- 일반 채팅 응답과 재추천 응답 처리 유틸 분리
- 재추천 요청 중 버튼 disabled 처리

## 🔗 관련 이슈

- closes #213 

## 📸 스크린샷 (선택)
<img width="821" height="700" alt="스크린샷 2026-04-28 152658" src="https://github.com/user-attachments/assets/1b4dcacd-d1b5-4db5-bc20-cdc97a60444b" />


## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
