### PR TITLE
feat: 챗봇카드 저장하기 api 연결

### DIFF
--- a/src/features/chat/page/ScentChat.tsx
+++ b/src/features/chat/page/ScentChat.tsx
@@ -10,13 +10,13 @@ import { useRetryChatRecommendationMutation } from "../hooks/useRetryChatRecomme
 import { useSendChatMessage } from "../hooks/useSendChatMessage"
 import { messages } from "../mocks/chat-mocks"
 import type { ChatMessage } from "../types/message.types"
+import { createMessageId } from "../utils/create-chat-id"
 import {
   createAssistantTextMessage,
   createTypingMessage,
   createUserMessage,
 } from "../utils/create-chat-message"
 import { handleChatResponse } from "../utils/handle-chat-response"
-
 import { handleRetryChatResponse } from "../utils/handle-retry-chat"
 import ChatHeader from "./chat-header/ChatHeader"
 import ChatInput from "./chat-input/ChatInput"
@@ -55,15 +55,13 @@ const ScentChat = () => {
       return
     }
 
-    const baseId = Date.now()
-
     const userMessage = createUserMessage({
-      id: baseId,
+      id: createMessageId(),
       text: trimmedText,
     })
 
     const typingMessage = createTypingMessage({
-      id: baseId + 1,
+      id: createMessageId(),
     })
 
     setChatMessages((prev) => [...prev, userMessage, typingMessage])
@@ -76,7 +74,6 @@ const ScentChat = () => {
 
       const assistantMessages = await handleChatResponse({
         responseData: response.data,
-        baseId,
       })
 
       setChatMessages((prev) => [
@@ -87,7 +84,7 @@ const ScentChat = () => {
       console.error(error)
 
       const errorMessage = createAssistantTextMessage({
-        id: baseId + 2,
+        id: createMessageId(),
         text: "메시지 전송에 실패했어요. 잠시 후 다시 시도해주세요.",
       })
 
@@ -103,10 +100,8 @@ const ScentChat = () => {
       return
     }
 
-    const baseId = Date.now()
-
     const typingMessage = createTypingMessage({
-      id: baseId,
+      id: createMessageId(),
     })
 
     setChatMessages((prev) => [...prev, typingMessage])
@@ -118,7 +113,6 @@ const ScentChat = () => {
 
       const retryMessages = await handleRetryChatResponse({
         responseData: retryResponse.data,
-        baseId,
       })
 
       setChatMessages((prev) => [
@@ -129,7 +123,7 @@ const ScentChat = () => {
       console.error(error)
 
       const errorMessage = createAssistantTextMessage({
-        id: baseId + 1,
+        id: createMessageId(),
         text: "다시 추천에 실패했어요. 잠시 후 다시 시도해주세요.",
       })
 

--- a/src/features/chat/page/chat-list/recommendation-card/RecommendationCard.tsx
+++ b/src/features/chat/page/chat-list/recommendation-card/RecommendationCard.tsx
@@ -1,6 +1,8 @@
 import { Button, Hstack, RoundBox, Tag, Vstack } from "@/shared/components"
 import EmptyImage from "@/shared/components/empty-image/EmptyImage"
+import { useSaveAnalysisFeedbackMutation } from "@/shared/hooks/useSaveAnalysisFeedback"
 import { useNavigate } from "@tanstack/react-router"
+import { useState } from "react"
 import type { RecommendationCardData } from "../../../types/message.types"
 import RecommendationActionButton from "./recommendation-button/RecommendationActionButton"
 
@@ -22,6 +24,10 @@ const RecommendationCard = ({
 }: RecommendationCardProps) => {
   const navigate = useNavigate()
   const hasImage = Boolean(imageSrc)
+  const [isSaved, setIsSaved] = useState(false)
+
+  const { mutate: saveAnalysisFeedbackMutate, isPending: isSaving } =
+    useSaveAnalysisFeedbackMutation()
 
   const handleClickDetail = () => {
     navigate({
@@ -33,6 +39,24 @@ const RecommendationCard = ({
         type: "chat",
       },
     })
+  }
+  const handleClickSave = () => {
+    if (isSaved) {
+      return
+    }
+
+    saveAnalysisFeedbackMutate(
+      {
+        id: recommendationId,
+        status: true,
+        type: "chatbot",
+      },
+      {
+        onSuccess: () => {
+          setIsSaved(true)
+        },
+      }
+    )
   }
 
   return (
@@ -74,7 +98,12 @@ const RecommendationCard = ({
             </Button>
 
             <Hstack>
-              <RecommendationActionButton>저장하기</RecommendationActionButton>
+              <RecommendationActionButton
+                onClick={handleClickSave}
+                disabled={isSaved || isSaving}
+              >
+                {isSaved ? "저장완료" : isSaving ? "저장 중..." : "저장하기"}
+              </RecommendationActionButton>
 
               <RecommendationActionButton
                 onClick={onRetry}

--- a/src/features/chat/utils/create-chat-id.ts
+++ b/src/features/chat/utils/create-chat-id.ts
@@ -1,0 +1,1 @@
+export const createMessageId = () => Date.now() + Math.random()

--- a/src/features/chat/utils/handle-chat-response.ts
+++ b/src/features/chat/utils/handle-chat-response.ts
@@ -3,25 +3,25 @@ import type {
   ChatMessage,
   SendChatMessageResponse,
 } from "../types/message.types"
+import { createMessageId } from "./create-chat-id"
 import {
   createAssistantTextMessage,
   createRecommendationMessage,
 } from "./create-chat-message"
+
 import { toRecommendationCardData } from "./to-recommendation-card-data"
 
 type HandleChatResponseParams = {
   responseData: SendChatMessageResponse["data"]
-  baseId: number
 }
 
 export const handleChatResponse = async ({
   responseData,
-  baseId,
 }: HandleChatResponseParams): Promise<ChatMessage[]> => {
   const { reply, is_recommendation, recommendation_id, scent_id } = responseData
 
   const assistantTextMessage = createAssistantTextMessage({
-    id: baseId + 2,
+    id: createMessageId(),
     text: reply,
   })
 
@@ -39,7 +39,7 @@ export const handleChatResponse = async ({
   }
 
   const recommendationMessage = createRecommendationMessage({
-    id: baseId + 3,
+    id: createMessageId(),
     data: recommendationCardData,
   })
 

--- a/src/features/chat/utils/handle-retry-chat.ts
+++ b/src/features/chat/utils/handle-retry-chat.ts
@@ -1,25 +1,25 @@
 import { getScentDetail } from "../api/scent-response-detail.api"
 import type { ChatMessage } from "../types/message.types"
 import type { RetryChatRecommendationResponse } from "../types/retry-chat.types"
+import { createMessageId } from "./create-chat-id"
 import {
   createAssistantTextMessage,
   createRecommendationMessage,
 } from "./create-chat-message"
+
 import { toRecommendationCardData } from "./to-recommendation-card-data"
 
 type HandleRetryChatResponseParams = {
   responseData: RetryChatRecommendationResponse["data"]
-  baseId: number
 }
 
 export const handleRetryChatResponse = async ({
   responseData,
-  baseId,
 }: HandleRetryChatResponseParams): Promise<ChatMessage[]> => {
   const { reply, recommendation_id, scent_id } = responseData
 
   const assistantTextMessage = createAssistantTextMessage({
-    id: baseId + 1,
+    id: createMessageId(),
     text: reply,
   })
 
@@ -33,7 +33,7 @@ export const handleRetryChatResponse = async ({
   }
 
   const recommendationMessage = createRecommendationMessage({
-    id: baseId + 2,
+    id: createMessageId(),
     data: recommendationCardData,
   })
 

--- a/src/shared/api/analysis-feedback.ts
+++ b/src/shared/api/analysis-feedback.ts
@@ -1,0 +1,34 @@
+import { instance } from "@/shared/api/axios-instance"
+
+type AnalysisFeedbackType = "image" | "chatbot" | "keyword" | "survey"
+
+type SaveAnalysisFeedbackParams = {
+  id: number
+  status: boolean
+  type: AnalysisFeedbackType
+}
+
+type SaveAnalysisFeedbackResponse = {
+  status: "success"
+  message?: string
+}
+
+export const saveAnalysisFeedback = async ({
+  id,
+  status,
+  type,
+}: SaveAnalysisFeedbackParams) => {
+  const { data } = await instance.patch<SaveAnalysisFeedbackResponse>(
+    `/analyses/feedback/${id}`,
+    {
+      status,
+    },
+    {
+      params: {
+        type,
+      },
+    }
+  )
+
+  return data
+}

--- a/src/shared/hooks/useSaveAnalysisFeedback.ts
+++ b/src/shared/hooks/useSaveAnalysisFeedback.ts
@@ -1,0 +1,8 @@
+import { useMutation } from "@tanstack/react-query"
+import { saveAnalysisFeedback } from "../api/analysis-feedback"
+
+export const useSaveAnalysisFeedbackMutation = () => {
+  return useMutation({
+    mutationFn: saveAnalysisFeedback,
+  })
+}


### PR DESCRIPTION
## 📌 작업 내용

- 챗봇 추천 결과 카드 저장 API 연결
- 분석 결과 저장 API 및 mutation hook 추가
- 저장 요청 시 `status`, `type` 파라미터 전달
- 채팅 메시지 key 중복 방지를 위한 message id 생성 방식 수정

## 🔗 관련 이슈

- closes #223 

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인