### PR TITLE
refactor: 결과 페이지 타입을 chatbot 기준으로 통일

### DIFF
--- a/src/features/chat/page/chat-input/ChatInput.tsx
+++ b/src/features/chat/page/chat-input/ChatInput.tsx
@@ -1,22 +1,37 @@
 import { Send } from "lucide-react"
-import { useState, type ChangeEvent, type KeyboardEvent } from "react"
+import {
+  useState,
+  type ChangeEvent,
+  type CompositionEvent,
+  type KeyboardEvent,
+} from "react"
 
 type ChatInputProps = {
   disabled?: boolean
   onSendMessage: (text: string) => void
 }
 
-const ChatInput = ({ onSendMessage }: ChatInputProps) => {
+const ChatInput = ({ disabled = false, onSendMessage }: ChatInputProps) => {
   const [inputValue, setInputValue] = useState("")
+  const [isComposing, setIsComposing] = useState(false)
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setInputValue(event.target.value)
   }
 
+  const handleCompositionStart = () => {
+    setIsComposing(true)
+  }
+
+  const handleCompositionEnd = (event: CompositionEvent<HTMLInputElement>) => {
+    setIsComposing(false)
+    setInputValue(event.currentTarget.value)
+  }
+
   const handleSend = () => {
     const trimmedValue = inputValue.trim()
 
-    if (!trimmedValue) {
+    if (!trimmedValue || disabled) {
       return
     }
 
@@ -25,7 +40,12 @@ const ChatInput = ({ onSendMessage }: ChatInputProps) => {
   }
 
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (isComposing || event.nativeEvent.isComposing) {
+      return
+    }
+
     if (event.key === "Enter") {
+      event.preventDefault()
       handleSend()
     }
   }
@@ -36,14 +56,19 @@ const ChatInput = ({ onSendMessage }: ChatInputProps) => {
         type="text"
         value={inputValue}
         onChange={handleChange}
+        onCompositionStart={handleCompositionStart}
+        onCompositionEnd={handleCompositionEnd}
         onKeyDown={handleKeyDown}
-        className="w-full rounded-md border border-border bg-green-input px-lg outline-none transition-colors focus:border-text-primary"
+        disabled={disabled}
+        className="w-full rounded-md border border-border bg-green-input px-lg outline-none transition-colors focus:border-text-primary disabled:cursor-not-allowed disabled:opacity-60"
         placeholder="메세지를 입력해주세요"
       />
+
       <button
         type="button"
         onClick={handleSend}
-        className="flex h-10 w-11 items-center justify-center rounded-md bg-primary text-white"
+        disabled={disabled}
+        className="flex h-10 w-11 items-center justify-center rounded-md bg-primary text-white disabled:cursor-not-allowed disabled:opacity-60"
       >
         <Send size={18} />
       </button>

--- a/src/features/chat/page/chat-list/recommendation-card/RecommendationCard.tsx
+++ b/src/features/chat/page/chat-list/recommendation-card/RecommendationCard.tsx
@@ -36,7 +36,7 @@ const RecommendationCard = ({
         resultId: String(recommendationId),
       },
       search: {
-        type: "chat",
+        type: "chatbot",
       },
     })
   }

--- a/src/features/result/page/ResultPage.tsx
+++ b/src/features/result/page/ResultPage.tsx
@@ -17,14 +17,14 @@ import BottomSection from "./sections/bottom-section/BottomSection"
 import TopCardSection from "./sections/card-section/TopCardSection"
 import ScentSection from "./sections/scent-section/ScentSection"
 
-type ResultType = "image" | "survey" | "keyword" | "chat"
+type ResultType = "image" | "survey" | "keyword" | "chatbot"
 
 type ResultPageProps = {
   resultId: number
   type: ResultType
 }
 
-const RESULT_STORAGE_KEY: Record<Exclude<ResultType, "chat">, string> = {
+const RESULT_STORAGE_KEY: Record<Exclude<ResultType, "chatbot">, string> = {
   image: "imageAnalysisResult",
   survey: "surveyAnalysisResult",
   keyword: "keywordAnalysisResult",
@@ -34,7 +34,7 @@ const ResultPage = ({ resultId, type }: ResultPageProps) => {
   const navigate = useNavigate()
 
   const storedResult = useMemo(() => {
-    if (type === "chat") {
+    if (type === "chatbot") {
       return undefined
     }
 

--- a/src/routes/_wide.find-scent.result.$resultId.tsx
+++ b/src/routes/_wide.find-scent.result.$resultId.tsx
@@ -3,14 +3,14 @@
 import ResultPage from "@/features/result/page/ResultPage"
 import { createFileRoute } from "@tanstack/react-router"
 
-type ResultType = "image" | "survey" | "keyword" | "chat"
+type ResultType = "image" | "survey" | "keyword" | "chatbot"
 
-const isResultType = (value: unknown): value is ResultType => {
+const isResultType = (type: unknown): type is ResultType => {
   return (
-    value === "image" ||
-    value === "survey" ||
-    value === "keyword" ||
-    value === "chat"
+    type === "image" ||
+    type === "survey" ||
+    type === "keyword" ||
+    type === "chatbot"
   )
 }
 

--- a/src/shared/api/analysis-deatil.api.ts
+++ b/src/shared/api/analysis-deatil.api.ts
@@ -1,15 +1,7 @@
 import { instance } from "@/shared/api/axios-instance"
 import type { ResultData } from "@/shared/types"
 
-type ResultType = "image" | "survey" | "keyword" | "chat"
-type AnalysisDetailApiType = "image" | "survey" | "keyword" | "chatbot"
-
-const ANALYSIS_DETAIL_API_TYPE: Record<ResultType, AnalysisDetailApiType> = {
-  image: "image",
-  survey: "survey",
-  keyword: "keyword",
-  chat: "chatbot",
-}
+type ResultType = "image" | "survey" | "keyword" | "chatbot"
 
 type GetAnalysisDetailParams = {
   id: number
@@ -22,7 +14,7 @@ export const getAnalysisDetail = async ({
 }: GetAnalysisDetailParams) => {
   const { data } = await instance.get<ResultData>(`/analyses/detail/${id}`, {
     params: {
-      type: ANALYSIS_DETAIL_API_TYPE[type],
+      type,
     },
   })
 

--- a/src/shared/hooks/useAnalysisDetailQuery.ts
+++ b/src/shared/hooks/useAnalysisDetailQuery.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
 import { getAnalysisDetail } from "../api/analysis-deatil.api"
 
-type ResultType = "image" | "survey" | "keyword" | "chat"
+type ResultType = "image" | "survey" | "keyword" | "chatbot"
 
 type UseAnalysisDetailQueryParams = {
   resultId: number


### PR DESCRIPTION
## 📌 작업 내용

- 결과 페이지 search type을 `chatbot` 기준으로 통일
- 히스토리 API에서 내려오는 `chatbot` 타입과 결과 페이지 타입 불일치 수정
- 분석 상세 조회 API 요청 시 type 변환 없이 그대로 전달하도록 수정
- 결과 페이지 라우트의 search validation에 `chatbot` 타입 추가
- `chat` 기준으로 남아있던 타입 조건을 `chatbot`으로 변경

## 🔗 관련 이슈

- closes #229 

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 히스토리에서 챗봇 결과 클릭 시 `/find-scent/result/:id?type=chatbot`으로 이동 확인
- [ ] 챗봇 결과 상세 API 요청 params가 `type=chatbot`으로 나가는지 확인
- [ ] 이미지/설문/키워드 결과 페이지 기존 동작 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인