### PR TITLE
feat: 회원가입 성공, 실패 모달

### DIFF
--- a/src/features/_narrow.signup/page/signup-modals/signup-error-modal/SignupErrorModal.tsx
+++ b/src/features/_narrow.signup/page/signup-modals/signup-error-modal/SignupErrorModal.tsx
@@ -5,8 +5,12 @@ import ModalContent from "@/shared/components/modal-content/ModalContent"
 const SignupErrorModal = () => {
   const modalKey = useSignupStore((state) => state.modalKey)
   const setModalKey = useSignupStore((state) => state.setModalKey)
+  const signupError = useSignupStore((state) => state.signupError)
 
   const handleClick = () => setModalKey(null)
+  const errorMessage = Object.entries(signupError.response.data)[0][1]
+
+  console.log({ signupError })
 
   return (
     <Modal isOpen={modalKey === "error"} onClose={() => setModalKey(null)}>
@@ -14,7 +18,7 @@ const SignupErrorModal = () => {
         <ModalContent.Title>
           회원 가입 중 오류가 발생했습니다
         </ModalContent.Title>
-        <ModalContent.Body>잠시 후 다시 시도해주세요</ModalContent.Body>
+        <ModalContent.Body>{errorMessage}</ModalContent.Body>
         <ModalContent.ButtonSection>
           <ModalContent.Button
             type="button"

--- a/src/features/_narrow.signup/page/signup-modals/signup-error-modal/SignupErrorModal.tsx
+++ b/src/features/_narrow.signup/page/signup-modals/signup-error-modal/SignupErrorModal.tsx
@@ -10,8 +10,6 @@ const SignupErrorModal = () => {
   const handleClick = () => setModalKey(null)
   const errorMessage = Object.entries(signupError.response.data)[0][1]
 
-  console.log({ signupError })
-
   return (
     <Modal isOpen={modalKey === "error"} onClose={() => setModalKey(null)}>
       <ModalContent>

--- a/src/features/_narrow.signup/page/signup-modals/signup-error-modal/SignupErrorModal.tsx
+++ b/src/features/_narrow.signup/page/signup-modals/signup-error-modal/SignupErrorModal.tsx
@@ -1,14 +1,30 @@
 import useSignupStore from "@/features/_narrow.signup/store/use-signup-store"
-import { Button, Modal } from "@/shared/components"
+import { Modal } from "@/shared/components"
+import ModalContent from "@/shared/components/modal-content/ModalContent"
 
 const SignupErrorModal = () => {
   const modalKey = useSignupStore((state) => state.modalKey)
   const setModalKey = useSignupStore((state) => state.setModalKey)
 
+  const handleClick = () => setModalKey(null)
+
   return (
     <Modal isOpen={modalKey === "error"} onClose={() => setModalKey(null)}>
-      <p>에러 발생: 내용물은 다음에 채우겠습니다</p>
-      <Button onClick={() => setModalKey(null)}>닫기</Button>
+      <ModalContent>
+        <ModalContent.Title>
+          회원 가입 중 오류가 발생했습니다
+        </ModalContent.Title>
+        <ModalContent.Body>잠시 후 다시 시도해주세요</ModalContent.Body>
+        <ModalContent.ButtonSection>
+          <ModalContent.Button
+            type="button"
+            onClick={handleClick}
+            role="cancel"
+          >
+            닫기
+          </ModalContent.Button>
+        </ModalContent.ButtonSection>
+      </ModalContent>
     </Modal>
   )
 }

--- a/src/features/_narrow.signup/page/signup-modals/signup-error-modal/SignupErrorModal.tsx
+++ b/src/features/_narrow.signup/page/signup-modals/signup-error-modal/SignupErrorModal.tsx
@@ -8,6 +8,9 @@ const SignupErrorModal = () => {
   const signupError = useSignupStore((state) => state.signupError)
 
   const handleClick = () => setModalKey(null)
+
+  if (!signupError?.response?.data) return null
+
   const errorMessage = Object.entries(signupError.response.data)[0][1]
 
   return (

--- a/src/features/_narrow.signup/page/signup-modals/signup-success-modal/SignupSuccessModal.tsx
+++ b/src/features/_narrow.signup/page/signup-modals/signup-success-modal/SignupSuccessModal.tsx
@@ -1,5 +1,6 @@
 import useSignupStore from "@/features/_narrow.signup/store/use-signup-store"
-import { Button, Modal } from "@/shared/components"
+import { Modal } from "@/shared/components"
+import ModalContent from "@/shared/components/modal-content/ModalContent"
 import { useNavigate } from "@tanstack/react-router"
 
 const SignupSuccessModal = () => {
@@ -15,10 +16,18 @@ const SignupSuccessModal = () => {
 
   return (
     <Modal isOpen={modalKey === "success"} onClose={() => setModalKey(null)}>
-      <p>성공: 내용물은 다음 이슈에서 채우겠습니다</p>
-      <Button type="button" onClick={handleClick}>
-        로그인 페이지로 이동
-      </Button>
+      <ModalContent>
+        <ModalContent.Title>회원가입이 완료되었습니다</ModalContent.Title>
+        <ModalContent.ButtonSection>
+          <ModalContent.Button
+            type="button"
+            onClick={handleClick}
+            role="confirm"
+          >
+            로그인 페이지로 이동
+          </ModalContent.Button>
+        </ModalContent.ButtonSection>
+      </ModalContent>
     </Modal>
   )
 }

--- a/src/features/_narrow.signup/page/use-signup/use-signup.ts
+++ b/src/features/_narrow.signup/page/use-signup/use-signup.ts
@@ -44,7 +44,7 @@ const useSignup = () => {
       plainInstance.post("accounts/signup", body),
     onSuccess: () => setModalKey("success"),
     onError: () => setModalKey("error"),
-    onSettled: (_data, error: AxiosError) => {
+    onSettled: (_data, error: AxiosError | null) => {
       setSignupError(error)
     },
   })

--- a/src/features/_narrow.signup/page/use-signup/use-signup.ts
+++ b/src/features/_narrow.signup/page/use-signup/use-signup.ts
@@ -1,6 +1,7 @@
 import { plainInstance } from "@/shared/api/axios-instance"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useMutation } from "@tanstack/react-query"
+import type { AxiosError } from "axios"
 import { useForm } from "react-hook-form"
 import z from "zod"
 import useSignupStore from "../../store/use-signup-store"
@@ -37,11 +38,15 @@ type SignupSchema = z.input<typeof signupSchema>
 
 const useSignup = () => {
   const setModalKey = useSignupStore((state) => state.setModalKey)
+  const setSignupError = useSignupStore((state) => state.setSignupError)
   const { mutate } = useMutation({
     mutationFn: (body: SignupSchema) =>
       plainInstance.post("accounts/signup", body),
     onSuccess: () => setModalKey("success"),
     onError: () => setModalKey("error"),
+    onSettled: (_data, error: AxiosError) => {
+      setSignupError(error)
+    },
   })
 
   const useFormReturns = useForm({ resolver: zodResolver(signupSchema) })

--- a/src/features/_narrow.signup/store/use-signup-store.ts
+++ b/src/features/_narrow.signup/store/use-signup-store.ts
@@ -6,7 +6,7 @@ type SignupStoreState = {
   setModalKey: (modelKey: "success" | "error" | null) => void
 
   signupError: AxiosError | null
-  setSignupError: (signupError: AxiosError) => void
+  setSignupError: (signupError: AxiosError | null) => void
 }
 
 const useSignupStore = create<SignupStoreState>()((set) => ({

--- a/src/features/_narrow.signup/store/use-signup-store.ts
+++ b/src/features/_narrow.signup/store/use-signup-store.ts
@@ -1,13 +1,20 @@
+import { AxiosError } from "axios"
 import { create } from "zustand"
 
 type SignupStoreState = {
   modalKey: "success" | "error" | null
   setModalKey: (modelKey: "success" | "error" | null) => void
+
+  signupError: AxiosError | null
+  setSignupError: (signupError: AxiosError) => void
 }
 
 const useSignupStore = create<SignupStoreState>()((set) => ({
   modalKey: null,
   setModalKey: (modalKey) => set({ modalKey }),
+
+  signupError: null,
+  setSignupError: (signupError) => set({ signupError }),
 }))
 
 export default useSignupStore

--- a/src/shared/components/inputs/Button/Button.tsx
+++ b/src/shared/components/inputs/Button/Button.tsx
@@ -46,14 +46,14 @@ const buttonVariants = cva("transition", {
   ],
 })
 
-// NOTE: pill = padding wide + radius full
-// NOTE: circle = padding same + radius full
+export type ButtonStyle = "contained" | "outlined" | "ghost"
 export type WithButtonProps = {
   size?: "sm" | "lg"
   padding?: "wide" | "same"
   radius?: "md" | "full"
-  style?: "contained" | "outlined" | "ghost"
+  style?: ButtonStyle
 }
+
 const Button = ({
   size = "sm",
   padding = "wide",

--- a/src/shared/components/modal-content/ModalContent.tsx
+++ b/src/shared/components/modal-content/ModalContent.tsx
@@ -1,0 +1,68 @@
+import cn from "@/lib/utils"
+import type { DefaultButtonProps, DivProps } from "@/shared/types"
+import type { ReactNode } from "react"
+import { Button } from "../inputs"
+import type { ButtonStyle } from "../inputs/Button/Button"
+import { RoundBox } from "../layouts"
+
+type ModalContentTitleProps = {
+  children: string
+}
+const ModalContentTitle = ({ children }: ModalContentTitleProps) => {
+  return <h1 className="text-lg font-bold">{children}</h1>
+}
+const ModalContentBody = (props: DivProps) => {
+  const { children, className, ...rest } = props
+  return (
+    <div {...rest} className={cn("", className)}>
+      {children}
+    </div>
+  )
+}
+type ModalContentButtonSectionProps = {
+  children: ReactNode
+}
+const ModalContentButtonSection = ({
+  children,
+}: ModalContentButtonSectionProps) => {
+  return <div>{children}</div>
+}
+type ModalButtonRole = "cancel" | "confirm" | "destruct"
+type WithModalContentButtonProps = {
+  role: ModalButtonRole
+}
+
+const ModalContentButton = ({
+  role,
+  ...props
+}: Omit<DefaultButtonProps, "style" | "className"> &
+  WithModalContentButtonProps) => {
+  const { children, ...rest } = props
+  const roleToButtonConfig: Record<
+    ModalButtonRole,
+    { style: ButtonStyle; className?: string }
+  > = {
+    cancel: { style: "outlined" },
+    confirm: { style: "contained" },
+    destruct: { style: "contained", className: "bg-status-error text-card" },
+  }
+  const buttonConfig = roleToButtonConfig[role]
+  return (
+    <Button {...rest} {...buttonConfig}>
+      {children}
+    </Button>
+  )
+}
+type ModalContentProps = {
+  children: ReactNode
+}
+const ModalContent = ({ children }: ModalContentProps) => {
+  return <RoundBox>{children}</RoundBox>
+}
+
+ModalContent.Title = ModalContentTitle
+ModalContent.Body = ModalContentBody
+ModalContent.ButtonSection = ModalContentButtonSection
+ModalContent.Button = ModalContentButton
+
+export default ModalContent

--- a/src/shared/components/modal-content/ModalContent.tsx
+++ b/src/shared/components/modal-content/ModalContent.tsx
@@ -1,20 +1,23 @@
 import cn from "@/lib/utils"
 import type { DefaultButtonProps, DivProps } from "@/shared/types"
+import clsx from "clsx"
 import type { ReactNode } from "react"
 import { Button } from "../inputs"
 import type { ButtonStyle } from "../inputs/Button/Button"
-import { RoundBox } from "../layouts"
+import { RoundBox, Vstack } from "../layouts"
+import HOrVStack from "../layouts/HOrVStack/HOrVStack"
 
 type ModalContentTitleProps = {
   children: string
 }
 const ModalContentTitle = ({ children }: ModalContentTitleProps) => {
-  return <h1 className="text-lg font-bold">{children}</h1>
+  return <h1 className="font-bold text-center">{children}</h1>
 }
+
 const ModalContentBody = (props: DivProps) => {
   const { children, className, ...rest } = props
   return (
-    <div {...rest} className={cn("", className)}>
+    <div {...rest} className={cn("flex-1 text-center", className)}>
       {children}
     </div>
   )
@@ -25,7 +28,7 @@ type ModalContentButtonSectionProps = {
 const ModalContentButtonSection = ({
   children,
 }: ModalContentButtonSectionProps) => {
-  return <div>{children}</div>
+  return <HOrVStack>{children}</HOrVStack>
 }
 type ModalButtonRole = "cancel" | "confirm" | "destruct"
 type WithModalContentButtonProps = {
@@ -48,7 +51,11 @@ const ModalContentButton = ({
   }
   const buttonConfig = roleToButtonConfig[role]
   return (
-    <Button {...rest} {...buttonConfig}>
+    <Button
+      {...rest}
+      style={buttonConfig.style}
+      className={clsx("w-full", buttonConfig.className)}
+    >
       {children}
     </Button>
   )
@@ -57,7 +64,13 @@ type ModalContentProps = {
   children: ReactNode
 }
 const ModalContent = ({ children }: ModalContentProps) => {
-  return <RoundBox>{children}</RoundBox>
+  return (
+    <RoundBox padding="xl">
+      <Vstack gap="xl" className="text-text-primary">
+        {children}
+      </Vstack>
+    </RoundBox>
+  )
 }
 
 ModalContent.Title = ModalContentTitle


### PR DESCRIPTION
## 📌 작업 내용

- 모달 내용물 (ModalContent)의 공통 컴포넌트를 제작했습니다
- 회원가입 성공, 실패 모달을 제작했습니다
- 실패 모달의 경우, 서버의 에러 메시지를 띄웁니다
- 성공 모달의 경우 테스트하지 못했으나 같은 공통 컴포넌트를 사용하여 스타일상의 문제는 없을 것으로 보입니다

## 🔗 관련 이슈

- closes #221

## 📸 스크린샷 (선택)

<img width="516" height="314" alt="image" src="https://github.com/user-attachments/assets/545cd3a0-724d-408a-9498-1164080d74c4" />


## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
