### PR TITLE
fix: 모바일 카메라 업로드 방식 개선

### DIFF
--- a/src/features/photo/page/ScentPhoto.tsx
+++ b/src/features/photo/page/ScentPhoto.tsx
@@ -32,7 +32,6 @@ const ScentPhoto = () => {
     isCreatingUploadUrl || isUploadingToS3 || isAnalyzingImage
 
   const hasImage = Boolean(selectedFile)
-  const isCameraStep = step === "camera"
 
   const handleBack = () => {
     navigate({ to: "/find-scent" })
@@ -98,16 +97,13 @@ const ScentPhoto = () => {
           setSelectedFile={setSelectedFile}
         />
 
-        {!isCameraStep && <PhotoTipsSection />}
-
-        {!isCameraStep && (
-          <Button
-            disabled={!hasImage || isSubmitting}
-            onClick={handleAnalyzeImage}
-          >
-            이미지 분석하기
-          </Button>
-        )}
+        <PhotoTipsSection />
+        <Button
+          disabled={!hasImage || isSubmitting}
+          onClick={handleAnalyzeImage}
+        >
+          이미지 분석하기
+        </Button>
       </Vstack>
     </Container>
   )

--- a/src/features/photo/page/photo-upload-section/PhotoUploadSection.tsx
+++ b/src/features/photo/page/photo-upload-section/PhotoUploadSection.tsx
@@ -8,7 +8,6 @@ import {
 } from "react"
 import type { MobilePhotoStep } from "../../types/mobile-photo-step.types"
 import PhotoActionButton from "../photo-action-button/PhotoActionButton"
-import MobileCameraContent from "./mobile-camera-content/MobileCameraContent"
 import UploadPreviewBox from "./upload-preview-box/UploadPreviewBox"
 
 type PhotoUploadSectionProps = {
@@ -26,8 +25,17 @@ const PhotoUploadSection = ({
   onStepChange,
   setSelectedFile,
 }: PhotoUploadSectionProps) => {
-  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const galleryInputRef = useRef<HTMLInputElement | null>(null)
+  const cameraInputRef = useRef<HTMLInputElement | null>(null)
   const objectUrlRef = useRef<string | null>(null)
+
+  const handleOpenGallery = () => {
+    galleryInputRef.current?.click()
+  }
+
+  const handleOpenCamera = () => {
+    cameraInputRef.current?.click()
+  }
 
   const revokeObjectUrl = () => {
     if (objectUrlRef.current) {
@@ -38,16 +46,10 @@ const PhotoUploadSection = ({
 
   const updatePreviewUrl = (nextPreviewUrl: string, isObjectUrl = false) => {
     revokeObjectUrl()
-
     if (isObjectUrl) {
       objectUrlRef.current = nextPreviewUrl
     }
-
     setPreviewUrl(nextPreviewUrl)
-  }
-
-  const handleOpenGallery = () => {
-    fileInputRef.current?.click()
   }
 
   const handleChangeImage = (event: ChangeEvent<HTMLInputElement>) => {
@@ -63,12 +65,6 @@ const PhotoUploadSection = ({
     onStepChange("preview")
 
     event.target.value = ""
-  }
-
-  const handleCaptureImage = (imageUrl: string, file: File) => {
-    setSelectedFile(file)
-    updatePreviewUrl(imageUrl, true)
-    onStepChange("preview")
   }
 
   useEffect(() => {
@@ -94,21 +90,11 @@ const PhotoUploadSection = ({
               <PhotoActionButton type="button" onClick={handleOpenGallery}>
                 갤러리 열기
               </PhotoActionButton>
-              <PhotoActionButton
-                type="button"
-                onClick={() => onStepChange("camera")}
-              >
+              <PhotoActionButton type="button" onClick={handleOpenCamera}>
                 카메라 열기
               </PhotoActionButton>
             </Hstack>
           </div>
-        )}
-
-        {step === "camera" && (
-          <MobileCameraContent
-            onCapture={handleCaptureImage}
-            onClose={() => onStepChange("select")}
-          />
         )}
 
         {step === "preview" && previewUrl && (
@@ -118,10 +104,7 @@ const PhotoUploadSection = ({
               <PhotoActionButton type="button" onClick={handleOpenGallery}>
                 다른 이미지 선택
               </PhotoActionButton>
-              <PhotoActionButton
-                type="button"
-                onClick={() => onStepChange("camera")}
-              >
+              <PhotoActionButton type="button" onClick={handleOpenCamera}>
                 카메라로 다시 찍기
               </PhotoActionButton>
             </Hstack>
@@ -130,9 +113,18 @@ const PhotoUploadSection = ({
       </section>
 
       <input
-        ref={fileInputRef}
+        ref={galleryInputRef}
         type="file"
         accept="image/*"
+        className="hidden"
+        onChange={handleChangeImage}
+      />
+
+      <input
+        ref={cameraInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
         className="hidden"
         onChange={handleChangeImage}
       />

--- a/src/features/photo/page/photo-upload-section/mobile-camera-content/MobileCameraContent.tsx
+++ b/src/features/photo/page/photo-upload-section/mobile-camera-content/MobileCameraContent.tsx
@@ -1,3 +1,5 @@
+// TODO : 카메라, 기본 UI로 변경 현 파일 보류
+
 import { RefreshCw, X } from "lucide-react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import CameraIconButton from "./camera-icon-button/CameraIconButton"

--- a/src/features/photo/types/mobile-photo-step.types.ts
+++ b/src/features/photo/types/mobile-photo-step.types.ts
@@ -1,1 +1,1 @@
-export type MobilePhotoStep = "select" | "camera" | "preview"
+export type MobilePhotoStep = "select" | "preview"


### PR DESCRIPTION
## 📌 작업 내용

- 모바일 카메라 촬영 방식을 `getUserMedia` 기반 커스텀 카메라에서 `input capture` 방식으로 변경
- 갤러리 업로드 input과 카메라 촬영 input 분리
- 모바일 사진 업로드 단계를 `select`, `preview`로 단순화
- 사용하지 않는 모바일 카메라 컴포넌트 및 관련 코드 제거
- 촬영/선택한 이미지 preview 처리 유지

## 🔗 관련 이슈

- closes #239 

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
- [ ] PC에서 이미지 선택 및 preview 동작 확인
- [ ] 모바일에서 갤러리 이미지 선택 확인
- [ ] 모바일에서 카메라 촬영 후 preview 전환 확인