### PR TITLE
fix: 인증 시 uuid 토큰 사용하도록 변경

### DIFF
--- a/src/features/_narrow.find-email/page/FindEmailPage.tsx
+++ b/src/features/_narrow.find-email/page/FindEmailPage.tsx
@@ -1,18 +1,12 @@
 import NarrowTitleSection from "@/features/_narrow/components/narrow-title-section/NarrowTitleSection"
 import { Button, Input, Vstack } from "@/shared/components"
 import Labeled from "@/shared/components/inputs/labeled/Labeled"
+import PhoneVerificationFields from "@/shared/components/verification-fields/phone-verification-fields/PhoneVerificationFields"
 import FindEmailSuccess from "./find-email-success/FindEmailSuccess"
 import useFindEmail from "./use-find-email/use-find-email"
 
 const FindEmailPage = () => {
-  const {
-    data,
-    errors,
-    register,
-    submitForm,
-    handlePhoneVerificationFirst,
-    handlePhoneVerificationSecond,
-  } = useFindEmail()
+  const { data, errors, register, submitForm, useFormReturn } = useFindEmail()
 
   // TODO: api 나오면 응답 타입 확인해야
   if (data) return <FindEmailSuccess email={data.data.email as string} />
@@ -37,37 +31,7 @@ const FindEmailPage = () => {
           </Labeled.Message>
         </Labeled>
 
-        <Labeled isError={Boolean(errors.phone_number)}>
-          <Labeled.Title>전화번호</Labeled.Title>
-          <Labeled.Body>
-            <Input
-              {...register("phone_number")}
-              status={errors.phone_number ? "error" : "none"}
-              type="number"
-              placeholder={`"-"없이 숫자만 입력해주세요`}
-              className="grow"
-            />
-            <Button type="button" onClick={handlePhoneVerificationFirst}>
-              인증
-            </Button>
-          </Labeled.Body>
-          <Labeled.Message>{errors.phone_number?.message}</Labeled.Message>
-        </Labeled>
-
-        <Labeled isError={Boolean(errors.phone_token)}>
-          <Labeled.Title>전화번호 인증코드</Labeled.Title>
-          <Labeled.Body>
-            <Input
-              {...register("phone_token")}
-              status={errors.phone_token ? "error" : "none"}
-              placeholder="6자리 코드를 입력해주세요"
-            />
-            <Button type="button" onClick={handlePhoneVerificationSecond}>
-              확인
-            </Button>
-          </Labeled.Body>
-          <Labeled.Message>{errors.phone_token?.message}</Labeled.Message>
-        </Labeled>
+        <PhoneVerificationFields useFormReturn={useFormReturn} />
 
         <Button className="mt-lg">이메일 찾기</Button>
       </Vstack>

--- a/src/features/_narrow.find-email/page/use-find-email/use-find-email.ts
+++ b/src/features/_narrow.find-email/page/use-find-email/use-find-email.ts
@@ -28,13 +28,13 @@ const useFindEmail = () => {
       // NOTE: 현재는 404가 뜹니다
       plainInstance.post("/accounts/find-email", body),
   })
+
+  const useFormReturn = useForm({ resolver: zodResolver(findEmailSchema) })
   const {
-    setValue,
-    watch,
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm({ resolver: zodResolver(findEmailSchema) })
+  } = useFormReturn
 
   const onSubmit = (data: FindEmailSchema) => {
     mutate(data)
@@ -42,37 +42,12 @@ const useFindEmail = () => {
 
   const submitForm = handleSubmit(onSubmit)
 
-  const handlePhoneVerificationFirst = async () => {
-    const phone_number = watch().phone_number
-    await plainInstance.post(
-      "https://fragmnt.pics/api/v1/accounts/verification/send-sms",
-      {
-        phone_number,
-      }
-    )
-  }
-
-  const handlePhoneVerificationSecond = async () => {
-    const phone_number = watch().phone_number
-    const phone_token = watch().phone_token
-    const response = await plainInstance.post<{
-      detail: string
-      sms_token: string
-    }>("https://fragmnt.pics/api/v1/accounts/verification/verify-sms", {
-      phone_number,
-      code: phone_token,
-    })
-    const token = response.data.sms_token
-    setValue("sms_uuid_token", token)
-  }
-
   return {
     data,
     register,
     errors,
     submitForm,
-    handlePhoneVerificationFirst,
-    handlePhoneVerificationSecond,
+    useFormReturn,
   }
 }
 

--- a/src/features/_narrow.find-password/page/FindPasswordPage.tsx
+++ b/src/features/_narrow.find-password/page/FindPasswordPage.tsx
@@ -1,19 +1,14 @@
 import NarrowTitleSection from "@/features/_narrow/components/narrow-title-section/NarrowTitleSection"
-import { Button, Input, Vstack } from "@/shared/components"
+import { Button, Vstack } from "@/shared/components"
 import Labeled from "@/shared/components/inputs/labeled/Labeled"
 import PasswordInput from "@/shared/components/inputs/password-input/PasswordInput"
+import EmailVerificationFields from "@/shared/components/verification-fields/email-verification-fields/EmailVerificationFields"
 import FindPasswordSuccess from "./find-password-success/FindPasswordSuccess"
 import useFindPassword from "./use-find-password/use-find-password"
 
 const FindPasswordPage = () => {
-  const {
-    errors,
-    register,
-    submitForm,
-    data,
-    handleEmailVerificationFirst,
-    handleEmailVerificationSecond,
-  } = useFindPassword()
+  const { errors, register, submitForm, data, useFormReturn } =
+    useFindPassword()
 
   // TODO: api 나오면 응답 타입 확인해야
   if (data) return <FindPasswordSuccess />
@@ -23,35 +18,8 @@ const FindPasswordPage = () => {
       <Vstack gap="xl">
         <NarrowTitleSection title="비밀번호 재설정" />
 
-        <Labeled isError={Boolean(errors.email)}>
-          <Labeled.Title>이메일</Labeled.Title>
-          <Labeled.Body>
-            <Input
-              {...register("email")}
-              placeholder="your@email.com"
-              status={errors.email ? "error" : "none"}
-            />
-            <Button type="button" onClick={handleEmailVerificationFirst}>
-              인증
-            </Button>
-          </Labeled.Body>
-          <Labeled.Message>{errors.email?.message}</Labeled.Message>
-        </Labeled>
+        <EmailVerificationFields useFormReturn={useFormReturn} />
 
-        <Labeled isError={Boolean(errors.email_token)}>
-          <Labeled.Title>이메일 인증코드</Labeled.Title>
-          <Labeled.Body>
-            <Input
-              {...register("email_token")}
-              status={errors.email_token ? "error" : "none"}
-              placeholder="6자리 코드를 입력해주세요"
-            />
-            <Button type="button" onClick={handleEmailVerificationSecond}>
-              확인
-            </Button>
-          </Labeled.Body>
-          <Labeled.Message>{errors.email_token?.message}</Labeled.Message>
-        </Labeled>
         <Labeled isError={Boolean(errors.new_password)}>
           <Labeled.Title>새 비밀번호</Labeled.Title>
           <PasswordInput

--- a/src/features/_narrow.find-password/page/use-find-password/use-find-password.ts
+++ b/src/features/_narrow.find-password/page/use-find-password/use-find-password.ts
@@ -40,7 +40,7 @@ const useFindPassword = () => {
     mutationFn: (body: FindPasswordSchema) =>
       // NOTE: api가 아직 나오지 않음
       // NOTE: 현재는 404가 뜹니다
-      plainInstance.post("/accounts/chang-password", body),
+      plainInstance.post("/accounts/change-password", body),
   })
 
   const useFormReturn = useForm({ resolver: zodResolver(findPasswordSchema) })

--- a/src/features/_narrow.find-password/page/use-find-password/use-find-password.ts
+++ b/src/features/_narrow.find-password/page/use-find-password/use-find-password.ts
@@ -42,13 +42,13 @@ const useFindPassword = () => {
       // NOTE: 현재는 404가 뜹니다
       plainInstance.post("/accounts/chang-password", body),
   })
+
+  const useFormReturn = useForm({ resolver: zodResolver(findPasswordSchema) })
   const {
-    setValue,
-    watch,
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm({ resolver: zodResolver(findPasswordSchema) })
+  } = useFormReturn
 
   const onSubmit = (data: FindPasswordSchema) => {
     mutate(data)
@@ -56,37 +56,12 @@ const useFindPassword = () => {
 
   const submitForm = handleSubmit(onSubmit)
 
-  const handleEmailVerificationFirst = async () => {
-    const email = watch().email
-    await plainInstance.post(
-      "https://fragmnt.pics/api/v1/accounts/verification/send-email",
-      {
-        email,
-      }
-    )
-  }
-  const handleEmailVerificationSecond = async () => {
-    const email = watch().email
-    const email_token = watch().email_token
-    const response = await plainInstance.post<{
-      detail: string
-      token: string
-    }>("https://fragmnt.pics/api/v1/accounts/verification/verify-email", {
-      email,
-      code: email_token,
-    })
-
-    const token = response.data.token
-    setValue("email_uuid_token", token)
-  }
-
   return {
     data,
     register,
     submitForm,
     errors,
-    handleEmailVerificationFirst,
-    handleEmailVerificationSecond,
+    useFormReturn,
   }
 }
 

--- a/src/features/_narrow.signup/page/use-signup/use-signup.ts
+++ b/src/features/_narrow.signup/page/use-signup/use-signup.ts
@@ -15,6 +15,7 @@ const signupSchema = z.object({
     .string()
     .min(6, "6자리의 인증번호를 입력해주세요")
     .max(6, "6자리의 인증번호를 입력해주세요"),
+  email_uuid_token: z.string().optional(),
   password: z
     .string()
     .min(1, "비밀번호를 입력해주세요")
@@ -28,6 +29,7 @@ const signupSchema = z.object({
     .string()
     .min(6, "6자리의 인증번호를 입력해주세요")
     .max(6, "6자리의 인증번호를 입력해주세요"),
+  sms_uuid_token: z.string().optional(),
   birthday: z
     .string()
     .min(8, "8자리의 생년월일을 입력해주세요")

--- a/src/shared/components/verification-fields/email-verification-fields/EmailVerificationFields.tsx
+++ b/src/shared/components/verification-fields/email-verification-fields/EmailVerificationFields.tsx
@@ -4,16 +4,16 @@ import Labeled from "../../inputs/labeled/Labeled"
 import type { EmailFields } from "../types/use-form-return.type"
 import useEmailVerification from "./use-email-verification/use-email-verification"
 
-type EmailVerificationFieldsProps = {
-  useFormReturn: UseFormReturn<EmailFields & Record<string, unknown>>
+type EmailVerificationFieldsProps<TFieldValues extends EmailFields> = {
+  useFormReturn: UseFormReturn<TFieldValues>
 }
-const EmailVerificationFields = ({
+const EmailVerificationFields = <TFieldValues extends EmailFields>({
   useFormReturn,
-}: EmailVerificationFieldsProps) => {
+}: EmailVerificationFieldsProps<TFieldValues>) => {
   const {
     register,
     formState: { errors },
-  } = useFormReturn
+  } = useFormReturn as unknown as UseFormReturn<EmailFields> // NOTE: 타입을 강제해서 이 이하에서는 type assertion이 필요 없게 합니다
 
   const {
     emailFirstData,

--- a/src/shared/components/verification-fields/email-verification-fields/EmailVerificationFields.tsx
+++ b/src/shared/components/verification-fields/email-verification-fields/EmailVerificationFields.tsx
@@ -1,15 +1,15 @@
-import type { Path, UseFormReturn } from "react-hook-form"
+import type { UseFormReturn } from "react-hook-form"
 import { Button, Input } from "../../inputs"
 import Labeled from "../../inputs/labeled/Labeled"
 import type { EmailFields } from "../types/use-form-return.type"
 import useEmailVerification from "./use-email-verification/use-email-verification"
 
-type EmailVerificationFieldsProps<TFieldValues extends EmailFields> = {
-  useFormReturn: UseFormReturn<TFieldValues, unknown, TFieldValues>
+type EmailVerificationFieldsProps = {
+  useFormReturn: UseFormReturn<EmailFields & Record<string, unknown>>
 }
-const EmailVerificationFields = <TFieldValues extends EmailFields>({
+const EmailVerificationFields = ({
   useFormReturn,
-}: EmailVerificationFieldsProps<TFieldValues>) => {
+}: EmailVerificationFieldsProps) => {
   const {
     register,
     formState: { errors },
@@ -36,7 +36,7 @@ const EmailVerificationFields = <TFieldValues extends EmailFields>({
         <Labeled.Title>이메일</Labeled.Title>
         <Labeled.Body>
           <Input
-            {...register("email" as Path<TFieldValues>)}
+            {...register("email")}
             placeholder="your@email.com"
             status={errors.email ? "error" : "none"}
           />
@@ -56,7 +56,7 @@ const EmailVerificationFields = <TFieldValues extends EmailFields>({
         <Labeled.Title>이메일 인증코드</Labeled.Title>
         <Labeled.Body>
           <Input
-            {...register("email_token" as Path<TFieldValues>)}
+            {...register("email_token")}
             status={secondInputStatus}
             placeholder="6자리 코드를 입력해주세요"
           />

--- a/src/shared/components/verification-fields/email-verification-fields/use-email-verification/use-email-verification.ts
+++ b/src/shared/components/verification-fields/email-verification-fields/use-email-verification/use-email-verification.ts
@@ -4,10 +4,11 @@ import type { AxiosError } from "axios"
 import type { UseFormReturn } from "react-hook-form"
 import type { EmailFields } from "../../types/use-form-return.type"
 
-const useEmailVerification = (
-  useFormReturns: UseFormReturn<EmailFields & Record<string, unknown>>
+const useEmailVerification = <TFieldValues extends EmailFields>(
+  useFormReturns: UseFormReturn<TFieldValues>
 ) => {
-  const { watch, setError, clearErrors, setValue } = useFormReturns
+  const { watch, setError, clearErrors, setValue } =
+    useFormReturns as unknown as UseFormReturn<EmailFields> // NOTE: 타입을 강제해서 이 이하에서는 type assertion이 필요 없게 합니다
 
   const {
     data: emailFirstData,
@@ -42,13 +43,13 @@ const useEmailVerification = (
     mutationFn: async () => {
       const email = watch().email
       const email_token = watch().email_token
-      return await plainInstance.post<{ email_uuid_token: string }>(
-        "https://fragmnt.pics/api/v1/accounts/verification/verify-email",
-        {
-          email,
-          code: email_token,
-        }
-      )
+      return await plainInstance.post<{
+        detail: string
+        email_uuid_token: string
+      }>("https://fragmnt.pics/api/v1/accounts/verification/verify-email", {
+        email,
+        code: email_token,
+      })
     },
     onSuccess: (response) => {
       clearErrors("email_token")

--- a/src/shared/components/verification-fields/email-verification-fields/use-email-verification/use-email-verification.ts
+++ b/src/shared/components/verification-fields/email-verification-fields/use-email-verification/use-email-verification.ts
@@ -1,13 +1,13 @@
 import { plainInstance } from "@/shared/api/axios-instance"
 import { useMutation } from "@tanstack/react-query"
 import type { AxiosError } from "axios"
-import type { Path, UseFormReturn } from "react-hook-form"
+import type { UseFormReturn } from "react-hook-form"
 import type { EmailFields } from "../../types/use-form-return.type"
 
-const useEmailVerification = <TFieldValues extends EmailFields>(
-  useFormReturns: UseFormReturn<TFieldValues>
+const useEmailVerification = (
+  useFormReturns: UseFormReturn<EmailFields & Record<string, unknown>>
 ) => {
-  const { watch, setError, clearErrors } = useFormReturns
+  const { watch, setError, clearErrors, setValue } = useFormReturns
 
   const {
     data: emailFirstData,
@@ -16,7 +16,7 @@ const useEmailVerification = <TFieldValues extends EmailFields>(
   } = useMutation({
     mutationFn: async () => {
       const email = watch().email
-      return await plainInstance.post(
+      return await plainInstance.post<{ detail: string }>(
         "https://fragmnt.pics/api/v1/accounts/verification/send-email",
         {
           email,
@@ -24,10 +24,10 @@ const useEmailVerification = <TFieldValues extends EmailFields>(
       )
     },
     onSuccess: () => {
-      clearErrors("email" as Path<TFieldValues>)
+      clearErrors("email")
     },
     onError: (error: AxiosError<{ error_detail: string }>) => {
-      setError("email" as Path<TFieldValues>, {
+      setError("email", {
         type: "custom",
         message: error.response?.data.error_detail,
       })
@@ -42,7 +42,7 @@ const useEmailVerification = <TFieldValues extends EmailFields>(
     mutationFn: async () => {
       const email = watch().email
       const email_token = watch().email_token
-      return await plainInstance.post(
+      return await plainInstance.post<{ email_uuid_token: string }>(
         "https://fragmnt.pics/api/v1/accounts/verification/verify-email",
         {
           email,
@@ -50,11 +50,12 @@ const useEmailVerification = <TFieldValues extends EmailFields>(
         }
       )
     },
-    onSuccess: () => {
-      clearErrors("email_token" as Path<TFieldValues>)
+    onSuccess: (response) => {
+      clearErrors("email_token")
+      setValue("email_uuid_token", response.data.email_uuid_token)
     },
     onError(error: AxiosError<{ detail: string }>) {
-      setError("email_token" as Path<TFieldValues>, {
+      setError("email_token", {
         type: "custom",
         message: error.response?.data.detail,
       })

--- a/src/shared/components/verification-fields/email-verification-fields/use-email-verification/use-email-verification.ts
+++ b/src/shared/components/verification-fields/email-verification-fields/use-email-verification/use-email-verification.ts
@@ -26,6 +26,7 @@ const useEmailVerification = <TFieldValues extends EmailFields>(
     },
     onSuccess: () => {
       clearErrors("email")
+      setValue("email_token", undefined)
     },
     onError: (error: AxiosError<{ error_detail: string }>) => {
       setError("email", {
@@ -45,7 +46,7 @@ const useEmailVerification = <TFieldValues extends EmailFields>(
       const email_token = watch().email_token
       return await plainInstance.post<{
         detail: string
-        email_uuid_token: string
+        token: string
       }>("https://fragmnt.pics/api/v1/accounts/verification/verify-email", {
         email,
         code: email_token,
@@ -53,7 +54,7 @@ const useEmailVerification = <TFieldValues extends EmailFields>(
     },
     onSuccess: (response) => {
       clearErrors("email_token")
-      setValue("email_uuid_token", response.data.email_uuid_token)
+      setValue("email_uuid_token", response.data.token)
     },
     onError(error: AxiosError<{ detail: string }>) {
       setError("email_token", {

--- a/src/shared/components/verification-fields/phone-verification-fields/PhoneVerificationFields.tsx
+++ b/src/shared/components/verification-fields/phone-verification-fields/PhoneVerificationFields.tsx
@@ -1,15 +1,15 @@
-import type { Path, UseFormReturn } from "react-hook-form"
+import type { UseFormReturn } from "react-hook-form"
 import { Button, Input } from "../../inputs"
 import Labeled from "../../inputs/labeled/Labeled"
 import type { PhoneFields } from "../types/use-form-return.type"
 import usePhoneVerification from "./use-phone-verification-fields/use-phone-verification-fields"
 
-type PhoneVerificationFieldsProps<TFieldValues extends PhoneFields> = {
-  useFormReturn: UseFormReturn<TFieldValues>
+type PhoneVerificationFieldsProps = {
+  useFormReturn: UseFormReturn<PhoneFields & Record<string, unknown>>
 }
-const PhoneVerificationFields = <TFieldValues extends PhoneFields>({
+const PhoneVerificationFields = ({
   useFormReturn,
-}: PhoneVerificationFieldsProps<TFieldValues>) => {
+}: PhoneVerificationFieldsProps) => {
   const {
     register,
     formState: { errors },
@@ -36,7 +36,7 @@ const PhoneVerificationFields = <TFieldValues extends PhoneFields>({
         <Labeled.Title>전화번호</Labeled.Title>
         <Labeled.Body>
           <Input
-            {...register("phone_number" as Path<TFieldValues>)}
+            {...register("phone_number")}
             status={errors.phone_number ? "error" : "none"}
             type="number"
             placeholder={`"-"없이 숫자만 입력해주세요`}
@@ -59,7 +59,7 @@ const PhoneVerificationFields = <TFieldValues extends PhoneFields>({
         <Labeled.Title>전화번호 인증코드</Labeled.Title>
         <Labeled.Body>
           <Input
-            {...register("phone_token" as Path<TFieldValues>)}
+            {...register("phone_token")}
             status={secondInputStatus}
             placeholder="6자리 코드를 입력해주세요"
           />

--- a/src/shared/components/verification-fields/phone-verification-fields/PhoneVerificationFields.tsx
+++ b/src/shared/components/verification-fields/phone-verification-fields/PhoneVerificationFields.tsx
@@ -4,16 +4,16 @@ import Labeled from "../../inputs/labeled/Labeled"
 import type { PhoneFields } from "../types/use-form-return.type"
 import usePhoneVerification from "./use-phone-verification-fields/use-phone-verification-fields"
 
-type PhoneVerificationFieldsProps = {
-  useFormReturn: UseFormReturn<PhoneFields & Record<string, unknown>>
+type PhoneVerificationFieldsProps<TFieldValues extends PhoneFields> = {
+  useFormReturn: UseFormReturn<TFieldValues>
 }
-const PhoneVerificationFields = ({
+const PhoneVerificationFields = <TFieldValues extends PhoneFields>({
   useFormReturn,
-}: PhoneVerificationFieldsProps) => {
+}: PhoneVerificationFieldsProps<TFieldValues>) => {
   const {
     register,
     formState: { errors },
-  } = useFormReturn
+  } = useFormReturn as unknown as UseFormReturn<PhoneFields> // NOTE: 타입을 강제해서 이 이하에서는 type assertion이 필요 없게 합니다
 
   const {
     phoneFirstData,

--- a/src/shared/components/verification-fields/phone-verification-fields/use-phone-verification-fields/use-phone-verification-fields.ts
+++ b/src/shared/components/verification-fields/phone-verification-fields/use-phone-verification-fields/use-phone-verification-fields.ts
@@ -1,13 +1,13 @@
 import { plainInstance } from "@/shared/api/axios-instance"
 import { useMutation } from "@tanstack/react-query"
 import type { AxiosError } from "axios"
-import type { Path, UseFormReturn } from "react-hook-form"
+import type { UseFormReturn } from "react-hook-form"
 import type { PhoneFields } from "../../types/use-form-return.type"
 
-const usePhoneVerification = <TFieldValues extends PhoneFields>(
-  useFormReturns: UseFormReturn<TFieldValues>
+const usePhoneVerification = (
+  useFormReturns: UseFormReturn<PhoneFields & Record<string, unknown>>
 ) => {
-  const { watch, setError, clearErrors } = useFormReturns
+  const { watch, setError, clearErrors, setValue } = useFormReturns
   const {
     data: phoneFirstData,
     mutate: phoneFirstMutate,
@@ -15,7 +15,7 @@ const usePhoneVerification = <TFieldValues extends PhoneFields>(
   } = useMutation({
     mutationFn: async () => {
       const phone_number = watch().phone_number
-      return await plainInstance.post(
+      return await plainInstance.post<{ detail: string }>(
         "https://fragmnt.pics/api/v1/accounts/verification/send-sms",
         {
           phone_number,
@@ -23,10 +23,10 @@ const usePhoneVerification = <TFieldValues extends PhoneFields>(
       )
     },
     onSuccess: () => {
-      clearErrors("phone_number" as Path<TFieldValues>)
+      clearErrors("phone_number")
     },
     onError(error: AxiosError<{ error_detail: string }>) {
-      setError("phone_number" as Path<TFieldValues>, {
+      setError("phone_number", {
         type: "custom",
         message: error.response?.data.error_detail,
       })
@@ -41,19 +41,20 @@ const usePhoneVerification = <TFieldValues extends PhoneFields>(
     mutationFn: async () => {
       const phone_number = watch().phone_number
       const phone_token = watch().phone_token
-      return await plainInstance.post(
-        "https://fragmnt.pics/api/v1/accounts/verification/verify-sms",
-        {
-          phone_number,
-          code: phone_token,
-        }
-      )
+      return await plainInstance.post<{
+        detail: string
+        sms_uuid_token: string
+      }>("https://fragmnt.pics/api/v1/accounts/verification/verify-sms", {
+        phone_number,
+        code: phone_token,
+      })
     },
-    onSuccess: () => {
-      clearErrors("phone_token" as Path<TFieldValues>)
+    onSuccess: (response) => {
+      clearErrors("phone_token")
+      setValue("sms_uuid_token", response.data.sms_uuid_token)
     },
     onError(error: AxiosError<{ detail: string }>) {
-      setError("phone_token" as Path<TFieldValues>, {
+      setError("phone_token", {
         type: "custom",
         message: error.response?.data.detail,
       })

--- a/src/shared/components/verification-fields/phone-verification-fields/use-phone-verification-fields/use-phone-verification-fields.ts
+++ b/src/shared/components/verification-fields/phone-verification-fields/use-phone-verification-fields/use-phone-verification-fields.ts
@@ -4,10 +4,11 @@ import type { AxiosError } from "axios"
 import type { UseFormReturn } from "react-hook-form"
 import type { PhoneFields } from "../../types/use-form-return.type"
 
-const usePhoneVerification = (
-  useFormReturns: UseFormReturn<PhoneFields & Record<string, unknown>>
+const usePhoneVerification = <TFieldValues extends PhoneFields>(
+  useFormReturns: UseFormReturn<TFieldValues>
 ) => {
-  const { watch, setError, clearErrors, setValue } = useFormReturns
+  const { watch, setError, clearErrors, setValue } =
+    useFormReturns as unknown as UseFormReturn<PhoneFields> // NOTE: 타입을 강제해서 이 이하에서는 type assertion이 필요 없게 합니다
   const {
     data: phoneFirstData,
     mutate: phoneFirstMutate,

--- a/src/shared/components/verification-fields/phone-verification-fields/use-phone-verification-fields/use-phone-verification-fields.ts
+++ b/src/shared/components/verification-fields/phone-verification-fields/use-phone-verification-fields/use-phone-verification-fields.ts
@@ -44,7 +44,7 @@ const usePhoneVerification = <TFieldValues extends PhoneFields>(
       const phone_token = watch().phone_token
       return await plainInstance.post<{
         detail: string
-        sms_uuid_token: string
+        sms_token: string
       }>("https://fragmnt.pics/api/v1/accounts/verification/verify-sms", {
         phone_number,
         code: phone_token,
@@ -52,7 +52,7 @@ const usePhoneVerification = <TFieldValues extends PhoneFields>(
     },
     onSuccess: (response) => {
       clearErrors("phone_token")
-      setValue("sms_uuid_token", response.data.sms_uuid_token)
+      setValue("sms_uuid_token", response.data.sms_token)
     },
     onError(error: AxiosError<{ detail: string }>) {
       setError("phone_token", {

--- a/src/shared/components/verification-fields/types/use-form-return.type.ts
+++ b/src/shared/components/verification-fields/types/use-form-return.type.ts
@@ -1,2 +1,10 @@
-export type EmailFields = { email?: string; email_token?: string }
-export type PhoneFields = { phone_number?: string; phone_token?: string }
+export type EmailFields = {
+  email?: string
+  email_token?: string
+  email_uuid_token?: string
+}
+export type PhoneFields = {
+  phone_number?: string
+  phone_token?: string
+  sms_uuid_token?: string
+}


### PR DESCRIPTION
## 📌 작업 내용

- 인증 공통 컴포넌트에서 uuid 토큰을 사용하도록 변경했습니다
- 이메일, 비밀번호 찾기에서도 해당 공통 컴포넌트를 사용하도록 변경했습니다
- react-hook-form의 UseFormReturn 타입이 제네릭으로도 확장이 되지 않아 type assertion을 사용한 부분이 있습니다
- 인증 로직 자체는 이메일, 비밀번호 찾기의 것과 동일합니다

## 🔗 관련 이슈

- closes #235

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
