### PR TITLE
feat: 공유하기 페이지 구현 및 API 연결

### DIFF
--- a/src/features/result/api/web-shared.api.ts
+++ b/src/features/result/api/web-shared.api.ts
@@ -1,7 +1,9 @@
 import { instance } from "@/shared/api/axios-instance"
+import type { ResultType } from "@/shared/types"
 
 type PostWebShareParams = {
   resultId: number
+  type: ResultType
 }
 
 type PostWebShareRequest = {
@@ -12,13 +14,13 @@ type PostWebShareResponse = {
   web_share_url: string
 }
 
-export const postWebShare = async ({ resultId }: PostWebShareParams) => {
+export const postWebShare = async ({ resultId, type }: PostWebShareParams) => {
   const body: PostWebShareRequest = {
     result_Id: resultId,
   }
 
   const { data } = await instance.post<PostWebShareResponse>(
-    `/question/web_share/${resultId}`,
+    `/${type}/web_share/${resultId}`,
     body
   )
 

--- a/src/features/result/api/web-shared.api.ts
+++ b/src/features/result/api/web-shared.api.ts
@@ -1,0 +1,26 @@
+import { instance } from "@/shared/api/axios-instance"
+
+type PostWebShareParams = {
+  resultId: number
+}
+
+type PostWebShareRequest = {
+  result_Id: number
+}
+
+type PostWebShareResponse = {
+  web_share_url: string
+}
+
+export const postWebShare = async ({ resultId }: PostWebShareParams) => {
+  const body: PostWebShareRequest = {
+    result_Id: resultId,
+  }
+
+  const { data } = await instance.post<PostWebShareResponse>(
+    `/question/web_share/${resultId}`,
+    body
+  )
+
+  return data
+}

--- a/src/features/result/api/web-shared.api.ts
+++ b/src/features/result/api/web-shared.api.ts
@@ -1,27 +1,22 @@
 import { instance } from "@/shared/api/axios-instance"
-import type { ResultType } from "@/shared/types"
 
 type PostWebShareParams = {
   resultId: number
-  type: ResultType
-}
-
-type PostWebShareRequest = {
-  result_Id: number
+  type: string
 }
 
 type PostWebShareResponse = {
-  web_share_url: string
+  share_id: string
+  og_crawler: string
 }
 
 export const postWebShare = async ({ resultId, type }: PostWebShareParams) => {
-  const body: PostWebShareRequest = {
-    result_Id: resultId,
-  }
-
   const { data } = await instance.post<PostWebShareResponse>(
-    `/${type}/web_share/${resultId}`,
-    body
+    "/analyses/web-share",
+    {
+      result_id: resultId,
+      type,
+    }
   )
 
   return data

--- a/src/features/result/hooks/usePostWebShare.ts
+++ b/src/features/result/hooks/usePostWebShare.ts
@@ -1,0 +1,8 @@
+import { useMutation } from "@tanstack/react-query"
+import { postWebShare } from "../api/web-shared.api"
+
+export const usePostWebShare = () => {
+  return useMutation({
+    mutationFn: postWebShare,
+  })
+}

--- a/src/features/result/page/sections/card-section/TopCardSection.tsx
+++ b/src/features/result/page/sections/card-section/TopCardSection.tsx
@@ -28,6 +28,7 @@ const TopCardSection = ({ result, type }: TopCardSectionProps) => {
   const { mutate: saveFeedback, isPending } = useSaveAnalysisFeedbackMutation()
   const { mutate: postWebShareMutate, isPending: isSharePending } =
     usePostWebShare()
+
   if (!recommendedScent || !result) {
     return (
       <div className="mt-2xl flex justify-center">
@@ -82,9 +83,11 @@ const TopCardSection = ({ result, type }: TopCardSectionProps) => {
         type,
       },
       {
-        onSuccess: async ({ web_share_url }) => {
+        onSuccess: async ({ share_id }) => {
+          const webShareUrl = `${window.location.origin}/share/${share_id}`
+
           try {
-            await navigator.clipboard.writeText(web_share_url)
+            await navigator.clipboard.writeText(webShareUrl)
             showToast("공유 링크가 복사되었습니다")
           } catch {
             showToast("공유 링크 복사에 실패했습니다", "error")

--- a/src/features/result/page/sections/card-section/TopCardSection.tsx
+++ b/src/features/result/page/sections/card-section/TopCardSection.tsx
@@ -79,6 +79,7 @@ const TopCardSection = ({ result, type }: TopCardSectionProps) => {
     postWebShareMutate(
       {
         resultId: result.id,
+        type,
       },
       {
         onSuccess: async ({ web_share_url }) => {

--- a/src/features/result/page/sections/card-section/TopCardSection.tsx
+++ b/src/features/result/page/sections/card-section/TopCardSection.tsx
@@ -1,9 +1,12 @@
 import EmptyStateImage from "@/assets/images/empty-state/empty-scent.svg"
-import { EmptyState } from "@/shared/components"
+import { EmptyState, Toast } from "@/shared/components"
 
+import { usePostWebShare } from "@/features/result/hooks/usePostWebShare"
+import type { ToastVariant } from "@/shared/components/toast"
 import { useSaveAnalysisFeedbackMutation } from "@/shared/hooks/useSaveAnalysisFeedback"
 import type { AnalysisResult, ResultType } from "@/shared/types"
 import { useNavigate } from "@tanstack/react-router"
+import { useState } from "react"
 import ResultTopCard from "./result-card/ResultCard"
 
 type TopCardSectionProps = {
@@ -13,13 +16,18 @@ type TopCardSectionProps = {
 
 const TopCardSection = ({ result, type }: TopCardSectionProps) => {
   const navigate = useNavigate()
+  const [toast, setToast] = useState<{
+    message: string
+    variant: ToastVariant
+  } | null>(null)
 
   const recommendedScent = result?.recommended_scent
   const matchScore = result?.match_score
   const isSaved = result?.is_saved ?? false
 
   const { mutate: saveFeedback, isPending } = useSaveAnalysisFeedbackMutation()
-
+  const { mutate: postWebShareMutate, isPending: isSharePending } =
+    usePostWebShare()
   if (!recommendedScent || !result) {
     return (
       <div className="mt-2xl flex justify-center">
@@ -56,8 +64,45 @@ const TopCardSection = ({ result, type }: TopCardSectionProps) => {
     })
   }
 
+  const showToast = (message: string, variant: ToastVariant = "success") => {
+    setToast({
+      message,
+      variant,
+    })
+
+    setTimeout(() => {
+      setToast(null)
+    }, 2000)
+  }
+
+  const handleClickShare = () => {
+    postWebShareMutate(
+      {
+        resultId: result.id,
+      },
+      {
+        onSuccess: async ({ web_share_url }) => {
+          try {
+            await navigator.clipboard.writeText(web_share_url)
+            showToast("공유 링크가 복사되었습니다")
+          } catch {
+            showToast("공유 링크 복사에 실패했습니다", "error")
+          }
+        },
+        onError: () => {
+          showToast("공유 링크 생성에 실패했습니다", "error")
+        },
+      }
+    )
+  }
+
   return (
     <section>
+      {toast && (
+        <div className="fixed left-1/2 top-xl z-50 w-[calc(100%-2rem)] max-w-[24rem] -translate-x-1/2">
+          <Toast message={toast.message} variant={toast.variant} />
+        </div>
+      )}
       <ResultTopCard
         engName={recommendedScent.eng_name}
         imageSrc={recommendedScent.thumbnail_url}
@@ -71,7 +116,9 @@ const TopCardSection = ({ result, type }: TopCardSectionProps) => {
         onDetailClick={handleClickDetail}
         onRetryClick={handleRetry}
         onAddCollectionClick={handleToggleSave}
+        onShareClick={handleClickShare}
         isSaved={isSaved}
+        isSharePending={isSharePending}
       />
     </section>
   )

--- a/src/features/result/page/sections/card-section/result-card/ResultCard.tsx
+++ b/src/features/result/page/sections/card-section/result-card/ResultCard.tsx
@@ -13,6 +13,7 @@ type ResultTopCardProps = {
   tags: string[]
   isSaved: boolean
   isSavePending?: boolean
+  isSharePending?: boolean
   onDetailClick?: () => void
   onAddCollectionClick?: () => void
   onRetryClick?: () => void
@@ -31,6 +32,7 @@ const ResultTopCard = ({
   tags,
   isSaved,
   isSavePending = false,
+  isSharePending = false,
   onDetailClick,
   onAddCollectionClick,
   onRetryClick,
@@ -109,7 +111,12 @@ const ResultTopCard = ({
                 <Heart size={20} fill={isSaved ? "currentColor" : "none"} />
               </Button>
 
-              <Button type="button" style="outlined" onClick={onShareClick}>
+              <Button
+                type="button"
+                style="outlined"
+                onClick={onShareClick}
+                disabled={isSharePending}
+              >
                 <Share2 size={18} />
               </Button>
             </div>

--- a/src/features/web-shared/api/web-shared.api.ts
+++ b/src/features/web-shared/api/web-shared.api.ts
@@ -1,0 +1,13 @@
+import { instance } from "@/shared/api/axios-instance"
+import type {
+  GetWebSharedParams,
+  GetWebSharedResponse,
+} from "../types/web-shared.types"
+
+export const getWebShared = async ({ shareId }: GetWebSharedParams) => {
+  const { data } = await instance.get<GetWebSharedResponse>(
+    `/analyses/web-share/${shareId}`
+  )
+
+  return data
+}

--- a/src/features/web-shared/hooks/useGetWebShared.ts
+++ b/src/features/web-shared/hooks/useGetWebShared.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query"
+import { getWebShared } from "../api/web-shared.api"
+
+type UseGetWebSharedParams = {
+  shareId: string
+}
+
+export const useGetWebShared = ({ shareId }: UseGetWebSharedParams) => {
+  return useQuery({
+    queryKey: ["web-shared", shareId],
+    queryFn: () => getWebShared({ shareId }),
+    enabled: Boolean(shareId),
+  })
+}

--- a/src/features/web-shared/page/WebSharedPage.tsx
+++ b/src/features/web-shared/page/WebSharedPage.tsx
@@ -1,0 +1,45 @@
+import { Route } from "@/routes/share.$shareId"
+import { Container, LoadingState, Vstack } from "@/shared/components"
+import { useGetWebShared } from "../hooks/useGetWebShared"
+import SharedError from "./shared-error/SharedError"
+import SharedFooter from "./shared-footer/SharedFooter"
+import SharedHeader from "./shared-header/SharedHeader"
+import SharedScentInfo from "./shared-scent-info/SharedScentInfo"
+import SharedScentVisual from "./shared-scent-visual/SharedScentVisual"
+
+const WebSharedPage = () => {
+  const { shareId } = Route.useParams()
+
+  const { data, isLoading, isError } = useGetWebShared({
+    shareId,
+  })
+
+  if (isLoading) {
+    return <LoadingState />
+  }
+
+  if (isError || !data?.recommended_scent) {
+    return <SharedError />
+  }
+
+  const scent = data.recommended_scent
+
+  return (
+    <main className="min-h-dvh">
+      <Container>
+        <div className="flex min-h-dvh items-center justify-center px-md py-lg">
+          <article className="fade-up w-full max-w-168 rounded-lg border border-border bg-white px-lg py-xl shadow-sm md:px-xl">
+            <Vstack>
+              <SharedHeader />
+              <SharedScentVisual scent={scent} />
+              <SharedScentInfo scent={scent} />
+              <SharedFooter />
+            </Vstack>
+          </article>
+        </div>
+      </Container>
+    </main>
+  )
+}
+
+export default WebSharedPage

--- a/src/features/web-shared/page/shared-error/SharedError.tsx
+++ b/src/features/web-shared/page/shared-error/SharedError.tsx
@@ -1,0 +1,5 @@
+const SharedError = () => {
+  return <div>SharedError</div>
+}
+
+export default SharedError

--- a/src/features/web-shared/page/shared-footer/SharedFooter.tsx
+++ b/src/features/web-shared/page/shared-footer/SharedFooter.tsx
@@ -1,0 +1,32 @@
+import { Link } from "@tanstack/react-router"
+
+const SharedFooter = () => {
+  return (
+    <footer className=" text-center">
+      <nav
+        aria-label="공유 결과 액션"
+        className=" flex w-full flex-col items-center gap-md"
+      >
+        <Link
+          to="/"
+          className="flex h-12 w-full items-center justify-center rounded-xl bg-primary px-lg text-sm font-semibold uppercase tracking-[0.18em] text-white transition-opacity hover:opacity-90 active:scale-[0.98]"
+        >
+          Find My Scent
+        </Link>
+
+        <Link
+          to="/scent-list"
+          className="text-sm font-medium uppercase tracking-[0.18em] text-primary/50 transition-opacity hover:opacity-80"
+        >
+          Explore Fragrances
+        </Link>
+      </nav>
+
+      <small className="mt-lg block text-xs font-medium tracking-[0.2em] text-primary/30">
+        FRAGMNT
+      </small>
+    </footer>
+  )
+}
+
+export default SharedFooter

--- a/src/features/web-shared/page/shared-header/SharedHeader.tsx
+++ b/src/features/web-shared/page/shared-header/SharedHeader.tsx
@@ -1,0 +1,15 @@
+const SharedHeader = () => {
+  return (
+    <header className="flex flex-col items-center gap-xs text-center">
+      <p className="text-xs font-semibold uppercase tracking-[0.32em] text-primary/60 md:text-sm">
+        SHARED FRAGRANCE STRIP
+      </p>
+
+      <p className="break-keep text-sm text-primary/45">
+        누군가의 향기 시향지가 도착했어요
+      </p>
+    </header>
+  )
+}
+
+export default SharedHeader

--- a/src/features/web-shared/page/shared-scent-info/SharedScentInfo.tsx
+++ b/src/features/web-shared/page/shared-scent-info/SharedScentInfo.tsx
@@ -1,0 +1,48 @@
+import type { WebSharedScent } from "../../types/web-shared.types"
+
+type SharedScentInfoProps = {
+  scent: WebSharedScent
+}
+
+const SharedScentInfo = ({ scent }: SharedScentInfoProps) => {
+  const formattedDescription = scent.description.replace(/\.\s*/g, ".\n").trim()
+
+  return (
+    <section
+      aria-labelledby="shared-scent-title"
+      className=" flex flex-col items-center text-center gap-md"
+    >
+      <p className="text-sm font-semibold uppercase tracking-[0.25em] text-primary/55">
+        {scent.eng_name}
+      </p>
+
+      <h1
+        id="shared-scent-title"
+        className=" text-[2rem] font-medium leading-tight tracking-tight text-primary md:text-[2.6rem]"
+      >
+        {scent.name}
+      </h1>
+
+      <ul
+        aria-label="향기 태그"
+        className=" flex flex-wrap justify-center gap-sm"
+      >
+        {scent.tags.map((tag) => (
+          <li
+            key={tag}
+            className="rounded-full px-md py-xs text-sm font-medium text-primary/60"
+          >
+            #{tag}
+          </li>
+        ))}
+      </ul>
+      <blockquote className="mx-auto mt-lg max-w-[34rem] px-md">
+        <p className="whitespace-pre-line break-keep text-sm leading-relaxed text-primary/70 md:text-md">
+          “{formattedDescription}”
+        </p>
+      </blockquote>
+    </section>
+  )
+}
+
+export default SharedScentInfo

--- a/src/features/web-shared/page/shared-scent-visual/SharedScentVisual.tsx
+++ b/src/features/web-shared/page/shared-scent-visual/SharedScentVisual.tsx
@@ -1,0 +1,43 @@
+import type { WebSharedScent } from "../../types/web-shared.types"
+import { SCENT_AXIS_LABELS } from "./shared-scent-visual.constants"
+import { getScentTheme, getScentVisualStyle } from "./shared-scent-visual.utils"
+
+type SharedScentVisualProps = {
+  scent: WebSharedScent
+}
+
+const SharedScentVisual = ({ scent }: SharedScentVisualProps) => {
+  const theme = getScentTheme(scent)
+  const scentStyle = getScentVisualStyle(scent)
+
+  return (
+    <section className="relative flex h-[360px] w-full items-center justify-center overflow-hidden">
+      <div
+        className={`shared-scent-diffusion absolute z-0 h-44 w-44 rounded-full ${theme.blobClassName} blur-xl`}
+        style={scentStyle}
+      />
+
+      <div
+        className={`shared-scent-axis-y absolute z-10 h-[260px] w-px origin-center ${theme.lineClassName}`}
+      />
+
+      <div
+        className={`shared-scent-axis-x absolute z-10 h-px w-[85%] origin-center ${theme.lineClassName}`}
+      />
+
+      {SCENT_AXIS_LABELS.map(({ positionClassName, label }) => {
+        return (
+          <span key={label} className={`absolute z-20 ${positionClassName}`}>
+            <span
+              className={`shared-scent-label block rounded-full px-sm py-[2px] text-xs font-medium backdrop-blur-sm ${theme.labelClassName}`}
+            >
+              {label}
+            </span>
+          </span>
+        )
+      })}
+    </section>
+  )
+}
+
+export default SharedScentVisual

--- a/src/features/web-shared/page/shared-scent-visual/shared-scent-visual.constants.ts
+++ b/src/features/web-shared/page/shared-scent-visual/shared-scent-visual.constants.ts
@@ -2,7 +2,7 @@ import type {
   ScentAxisLabel,
   ScentFamily,
   VisualTheme,
-} from "./shared-scent-visual.types"
+} from "../../types/web-shared.types"
 
 export const FAMILY_THEME_MAP: Record<ScentFamily, VisualTheme[]> = {
   floral: [

--- a/src/features/web-shared/page/shared-scent-visual/shared-scent-visual.constants.ts
+++ b/src/features/web-shared/page/shared-scent-visual/shared-scent-visual.constants.ts
@@ -1,0 +1,184 @@
+import type {
+  ScentAxisLabel,
+  ScentFamily,
+  VisualTheme,
+} from "./shared-scent-visual.types"
+
+export const FAMILY_THEME_MAP: Record<ScentFamily, VisualTheme[]> = {
+  floral: [
+    {
+      blobClassName:
+        "bg-gradient-to-br from-rose-500 via-pink-400 to-fuchsia-400",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+    {
+      blobClassName:
+        "bg-gradient-to-br from-purple-500 via-violet-400 to-rose-300",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+    {
+      blobClassName:
+        "bg-gradient-to-br from-rose-400 via-pink-300 to-purple-300",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+  ],
+  citrus: [
+    {
+      blobClassName:
+        "bg-gradient-to-br from-yellow-400 via-lime-300 to-sky-300",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+    {
+      blobClassName:
+        "bg-gradient-to-br from-orange-400 via-yellow-300 to-lime-300",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+    {
+      blobClassName:
+        "bg-gradient-to-br from-amber-400 via-yellow-300 to-cyan-300",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+  ],
+  woody: [
+    {
+      blobClassName:
+        "bg-gradient-to-br from-amber-500 via-orange-300 to-lime-300",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+    {
+      blobClassName:
+        "bg-gradient-to-br from-stone-500 via-amber-400 to-emerald-300",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+    {
+      blobClassName:
+        "bg-gradient-to-br from-orange-500 via-amber-400 to-stone-400",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+  ],
+  musk: [
+    {
+      blobClassName: "bg-gradient-to-br from-zinc-300 via-slate-200 to-sky-200",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+    {
+      blobClassName:
+        "bg-gradient-to-br from-stone-200 via-zinc-200 to-emerald-200",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+    {
+      blobClassName:
+        "bg-gradient-to-br from-slate-300 via-zinc-200 to-cyan-200",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+  ],
+  green: [
+    {
+      blobClassName:
+        "bg-gradient-to-br from-emerald-500 via-lime-300 to-teal-300",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+    {
+      blobClassName:
+        "bg-gradient-to-br from-lime-400 via-emerald-300 to-green-300",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+    {
+      blobClassName:
+        "bg-gradient-to-br from-green-500 via-emerald-300 to-cyan-300",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+  ],
+  aquatic: [
+    {
+      blobClassName: "bg-gradient-to-br from-sky-500 via-cyan-300 to-teal-300",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+    {
+      blobClassName:
+        "bg-gradient-to-br from-blue-400 via-sky-300 to-emerald-200",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+    {
+      blobClassName: "bg-gradient-to-br from-cyan-400 via-sky-300 to-blue-300",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+  ],
+  spicy: [
+    {
+      blobClassName:
+        "bg-gradient-to-br from-red-400 via-orange-400 to-amber-300",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+    {
+      blobClassName:
+        "bg-gradient-to-br from-amber-500 via-red-300 to-stone-300",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+    {
+      blobClassName:
+        "bg-gradient-to-br from-orange-500 via-amber-400 to-rose-300",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+  ],
+  powdery: [
+    {
+      blobClassName:
+        "bg-gradient-to-br from-rose-200 via-violet-200 to-stone-200",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+    {
+      blobClassName:
+        "bg-gradient-to-br from-zinc-200 via-pink-200 to-purple-200",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+    {
+      blobClassName:
+        "bg-gradient-to-br from-stone-200 via-rose-200 to-slate-200",
+      lineClassName: "bg-black/35",
+      labelClassName: "bg-white/80 text-black/60",
+    },
+  ],
+}
+
+export const SCENT_AXIS_LABELS: ScentAxisLabel[] = [
+  {
+    positionClassName: "left-4 top-1/2 -translate-y-1/2",
+    label: "차분함",
+  },
+  {
+    positionClassName: "right-4 top-1/2 -translate-y-1/2",
+    label: "산뜻함",
+  },
+  {
+    positionClassName: "left-1/2 top-6 -translate-x-1/2",
+    label: "포근함",
+  },
+  {
+    positionClassName: "bottom-6 left-1/2 -translate-x-1/2",
+    label: "부드러움",
+  },
+]

--- a/src/features/web-shared/page/shared-scent-visual/shared-scent-visual.utils.ts
+++ b/src/features/web-shared/page/shared-scent-visual/shared-scent-visual.utils.ts
@@ -1,7 +1,6 @@
 import type { CSSProperties } from "react"
-import type { WebSharedScent } from "../../types/web-shared.types"
+import type { ScentFamily, WebSharedScent } from "../../types/web-shared.types"
 import { FAMILY_THEME_MAP } from "./shared-scent-visual.constants"
-import type { ScentFamily } from "./shared-scent-visual.types"
 
 export const getAllNoteItems = (scent: WebSharedScent) => {
   const { top, middle, base } = scent.scent_notes

--- a/src/features/web-shared/page/shared-scent-visual/shared-scent-visual.utils.ts
+++ b/src/features/web-shared/page/shared-scent-visual/shared-scent-visual.utils.ts
@@ -1,0 +1,126 @@
+import type { CSSProperties } from "react"
+import type { WebSharedScent } from "../../types/web-shared.types"
+import { FAMILY_THEME_MAP } from "./shared-scent-visual.constants"
+import type { ScentFamily } from "./shared-scent-visual.types"
+
+export const getAllNoteItems = (scent: WebSharedScent) => {
+  const { top, middle, base } = scent.scent_notes
+
+  return [...top.items, ...middle.items, ...base.items].join(" ")
+}
+
+export const getScentFamily = (scent: WebSharedScent): ScentFamily => {
+  const tags = scent.tags.join(" ")
+  const noteItems = getAllNoteItems(scent)
+
+  if (
+    tags.includes("플로럴") ||
+    noteItems.includes("로즈") ||
+    noteItems.includes("피오니") ||
+    noteItems.includes("제라늄") ||
+    noteItems.includes("자스민")
+  ) {
+    return "floral"
+  }
+
+  if (
+    noteItems.includes("베르가못") ||
+    noteItems.includes("레몬") ||
+    noteItems.includes("오렌지") ||
+    noteItems.includes("자몽")
+  ) {
+    return "citrus"
+  }
+
+  if (
+    noteItems.includes("시더우드") ||
+    noteItems.includes("샌달우드") ||
+    noteItems.includes("패출리") ||
+    noteItems.includes("우드")
+  ) {
+    return "woody"
+  }
+
+  if (
+    noteItems.includes("머스크") ||
+    tags.includes("정돈된") ||
+    tags.includes("깨끗한")
+  ) {
+    return "musk"
+  }
+
+  if (
+    noteItems.includes("그린") ||
+    noteItems.includes("리프") ||
+    tags.includes("허브")
+  ) {
+    return "green"
+  }
+
+  if (
+    tags.includes("산뜻한") ||
+    tags.includes("청량한") ||
+    tags.includes("시원한")
+  ) {
+    return "aquatic"
+  }
+
+  if (
+    tags.includes("스파이시") ||
+    noteItems.includes("페퍼") ||
+    noteItems.includes("클로브")
+  ) {
+    return "spicy"
+  }
+
+  if (
+    tags.includes("잔잔한") ||
+    tags.includes("포근한") ||
+    tags.includes("부드러운")
+  ) {
+    return "powdery"
+  }
+
+  return "floral"
+}
+
+export const getStableIndex = ({
+  text,
+  length,
+}: {
+  text: string
+  length: number
+}) => {
+  const sum = text.split("").reduce((accumulator, character) => {
+    return accumulator + character.charCodeAt(0)
+  }, 0)
+
+  return sum % length
+}
+
+export const getScentTheme = (scent: WebSharedScent) => {
+  const family = getScentFamily(scent)
+  const variants = FAMILY_THEME_MAP[family]
+  const variantIndex = getStableIndex({
+    text: scent.name,
+    length: variants.length,
+  })
+
+  return variants[variantIndex]
+}
+
+export const getScentVisualStyle = (scent: WebSharedScent) => {
+  const { profile } = scent
+
+  const horizontalPosition = (profile.freshness - profile.depth) * 1.2
+  const verticalPosition = (profile.warmth - profile.softness) * 1.2
+  const scale = 0.78 + profile.softness / 320
+  const opacity = 0.82
+
+  return {
+    "--scent-x": `${horizontalPosition}px`,
+    "--scent-y": `${verticalPosition}px`,
+    "--scent-scale": scale,
+    "--scent-opacity": opacity,
+  } as CSSProperties
+}

--- a/src/features/web-shared/types/web-shared.types.ts
+++ b/src/features/web-shared/types/web-shared.types.ts
@@ -1,0 +1,43 @@
+export type ScentProfile = {
+  depth: number
+  warmth: number
+  softness: number
+  freshness: number
+  sweetness: number
+}
+
+export type ScentNoteGroup = {
+  items: string[]
+  title: string
+  description: string
+}
+
+export type ScentNotes = {
+  top: ScentNoteGroup
+  middle: ScentNoteGroup
+  base: ScentNoteGroup
+}
+
+export type WebSharedScent = {
+  name: string
+  eng_name: string
+  description: string
+  tags: string[]
+  profile: ScentProfile
+  scent_notes: ScentNotes
+  thumbnail_url: string
+}
+
+export type WebSharedResult = {
+  id: number
+  recommended_scent: WebSharedScent
+  created_at: string
+  ai_comment: string | null
+  match_score: number | null
+}
+
+export type GetWebSharedParams = {
+  shareId: string
+}
+
+export type GetWebSharedResponse = WebSharedResult

--- a/src/features/web-shared/types/web-shared.types.ts
+++ b/src/features/web-shared/types/web-shared.types.ts
@@ -41,3 +41,24 @@ export type GetWebSharedParams = {
 }
 
 export type GetWebSharedResponse = WebSharedResult
+
+export type ScentFamily =
+  | "floral"
+  | "citrus"
+  | "woody"
+  | "musk"
+  | "green"
+  | "aquatic"
+  | "spicy"
+  | "powdery"
+
+export type VisualTheme = {
+  blobClassName: string
+  lineClassName: string
+  labelClassName: string
+}
+
+export type ScentAxisLabel = {
+  positionClassName: string
+  label: string
+}

--- a/src/index.css
+++ b/src/index.css
@@ -334,3 +334,102 @@ body {
     transform: translateY(0);
   }
 }
+
+@keyframes shared-scent-diffusion {
+  0% {
+    opacity: 0;
+    transform: translate(var(--scent-x), var(--scent-y)) scale(0.2);
+    filter: blur(34px);
+  }
+
+  65% {
+    opacity: var(--scent-opacity);
+    transform: translate(var(--scent-x), var(--scent-y))
+      scale(calc(var(--scent-scale) * 1.06));
+    filter: blur(20px);
+  }
+
+  100% {
+    opacity: var(--scent-opacity);
+    transform: translate(var(--scent-x), var(--scent-y))
+      scale(var(--scent-scale));
+    filter: blur(22px);
+  }
+}
+
+@keyframes shared-scent-breath {
+  0% {
+    transform: translate(var(--scent-x), var(--scent-y))
+      scale(var(--scent-scale));
+    filter: blur(22px);
+  }
+
+  50% {
+    transform: translate(var(--scent-x), var(--scent-y))
+      scale(calc(var(--scent-scale) * 1.035));
+    filter: blur(18px);
+  }
+
+  100% {
+    transform: translate(var(--scent-x), var(--scent-y))
+      scale(var(--scent-scale));
+    filter: blur(22px);
+  }
+}
+
+@keyframes shared-scent-axis-x {
+  from {
+    opacity: 0;
+    transform: scaleX(0);
+  }
+
+  to {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+}
+
+@keyframes shared-scent-axis-y {
+  from {
+    opacity: 0;
+    transform: scaleY(0);
+  }
+
+  to {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+
+@keyframes shared-scent-label {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.shared-scent-diffusion {
+  animation:
+    shared-scent-diffusion 1.8s ease-out forwards,
+    shared-scent-breath 5.5s ease-in-out 1.8s infinite;
+}
+
+.shared-scent-axis-x {
+  opacity: 0;
+  animation: shared-scent-axis-x 0.9s ease-out 0.45s forwards;
+}
+
+.shared-scent-axis-y {
+  opacity: 0;
+  animation: shared-scent-axis-y 0.9s ease-out 0.3s forwards;
+}
+
+.shared-scent-label {
+  opacity: 0;
+  animation: shared-scent-label 0.6s ease-out 0.95s forwards;
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as WideRouteImport } from './routes/_wide'
 import { Route as NarrowRouteImport } from './routes/_narrow'
 import { Route as WideIndexRouteImport } from './routes/_wide.index'
+import { Route as ShareShareIdRouteImport } from './routes/share.$shareId'
 import { Route as WideScentListRouteImport } from './routes/_wide.scent-list'
 import { Route as WideScentDetailRouteImport } from './routes/_wide.scent-detail'
 import { Route as WideReviewRouteImport } from './routes/_wide.review'
@@ -41,6 +42,11 @@ const WideIndexRoute = WideIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => WideRoute,
+} as any)
+const ShareShareIdRoute = ShareShareIdRouteImport.update({
+  id: '/share/$shareId',
+  path: '/share/$shareId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const WideScentListRoute = WideScentListRouteImport.update({
   id: '/scent-list',
@@ -136,6 +142,7 @@ export interface FileRoutesByFullPath {
   '/review': typeof WideReviewRoute
   '/scent-detail': typeof WideScentDetailRoute
   '/scent-list': typeof WideScentListRoute
+  '/share/$shareId': typeof ShareShareIdRoute
   '/find-scent/chat': typeof WideFindScentChatRoute
   '/find-scent/keyword': typeof WideFindScentKeywordRoute
   '/find-scent/photo': typeof WideFindScentPhotoRoute
@@ -154,6 +161,7 @@ export interface FileRoutesByTo {
   '/review': typeof WideReviewRoute
   '/scent-detail': typeof WideScentDetailRoute
   '/scent-list': typeof WideScentListRoute
+  '/share/$shareId': typeof ShareShareIdRoute
   '/find-scent/chat': typeof WideFindScentChatRoute
   '/find-scent/keyword': typeof WideFindScentKeywordRoute
   '/find-scent/photo': typeof WideFindScentPhotoRoute
@@ -175,6 +183,7 @@ export interface FileRoutesById {
   '/_wide/review': typeof WideReviewRoute
   '/_wide/scent-detail': typeof WideScentDetailRoute
   '/_wide/scent-list': typeof WideScentListRoute
+  '/share/$shareId': typeof ShareShareIdRoute
   '/_wide/': typeof WideIndexRoute
   '/_wide/find-scent/chat': typeof WideFindScentChatRoute
   '/_wide/find-scent/keyword': typeof WideFindScentKeywordRoute
@@ -197,6 +206,7 @@ export interface FileRouteTypes {
     | '/review'
     | '/scent-detail'
     | '/scent-list'
+    | '/share/$shareId'
     | '/find-scent/chat'
     | '/find-scent/keyword'
     | '/find-scent/photo'
@@ -215,6 +225,7 @@ export interface FileRouteTypes {
     | '/review'
     | '/scent-detail'
     | '/scent-list'
+    | '/share/$shareId'
     | '/find-scent/chat'
     | '/find-scent/keyword'
     | '/find-scent/photo'
@@ -235,6 +246,7 @@ export interface FileRouteTypes {
     | '/_wide/review'
     | '/_wide/scent-detail'
     | '/_wide/scent-list'
+    | '/share/$shareId'
     | '/_wide/'
     | '/_wide/find-scent/chat'
     | '/_wide/find-scent/keyword'
@@ -247,6 +259,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   NarrowRoute: typeof NarrowRouteWithChildren
   WideRoute: typeof WideRouteWithChildren
+  ShareShareIdRoute: typeof ShareShareIdRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -271,6 +284,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof WideIndexRouteImport
       parentRoute: typeof WideRoute
+    }
+    '/share/$shareId': {
+      id: '/share/$shareId'
+      path: '/share/$shareId'
+      fullPath: '/share/$shareId'
+      preLoaderRoute: typeof ShareShareIdRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/_wide/scent-list': {
       id: '/_wide/scent-list'
@@ -451,6 +471,7 @@ const WideRouteWithChildren = WideRoute._addFileChildren(WideRouteChildren)
 const rootRouteChildren: RootRouteChildren = {
   NarrowRoute: NarrowRouteWithChildren,
   WideRoute: WideRouteWithChildren,
+  ShareShareIdRoute: ShareShareIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/share.$shareId.tsx
+++ b/src/routes/share.$shareId.tsx
@@ -1,0 +1,6 @@
+import WebSharedPage from "@/features/web-shared/page/WebSharedPage"
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/share/$shareId")({
+  component: WebSharedPage,
+})


### PR DESCRIPTION
## 📌 작업 내용

- 공유 결과 페이지에 향기 비주얼 인터랙션을 추가했습니다.
- 향기 태그와 노트 데이터를 기반으로 비주얼 테마 색상을 분기했습니다.
- 향기 프로필 데이터를 기반으로 오브젝트 위치, 크기, 투명도를 조정했습니다.
- 십자 축 라벨과 확산/호흡 애니메이션을 추가했습니다.
- 비주얼 테마 상수와 유틸 로직을 분리했습니다.

## 🔗 관련 이슈

- closes #246 

## 📸 스크린샷 (선택)
<img width="911" height="892" alt="스크린샷 2026-05-04 155033" src="https://github.com/user-attachments/assets/50b807f4-678f-42a4-9124-e6d1cb276320" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인