### PR TITLE
feat: 메인 페이지 버튼 기능 넣기

### DIFF
--- a/src/features/_narrow/layout/NarrowLayout.tsx
+++ b/src/features/_narrow/layout/NarrowLayout.tsx
@@ -9,7 +9,11 @@ import { Outlet } from "@tanstack/react-router"
 const NarrowLayout = () => {
   return (
     <FullScreen>
-      <FlexOneContainer isYScrollable className="max-h-screen py-2xl">
+      <FlexOneContainer
+        isYScrollable
+        className="max-h-screen py-2xl"
+        id="main-scrollable-area"
+      >
         <Container width="lg">
           <RoundBox className="bg-card shadow-box" padding="2xl">
             <Outlet />

--- a/src/features/_wide.index/mocks/mock-data/main-review-mock.ts
+++ b/src/features/_wide.index/mocks/mock-data/main-review-mock.ts
@@ -24,6 +24,7 @@ export const MainReviewMock: ReviewInMain[] = Array.from(
   { length: 11 },
   (_, index) => ({
     id: index,
+    type: "keyword",
     thumbnail_url: imgUrls[index % imgUrls.length],
     name: `더미유저${index + 1}`,
     created_at: new Date(Date.now() - index * 86400000).toISOString(),

--- a/src/features/_wide.index/page/1-introduction/Introduction.tsx
+++ b/src/features/_wide.index/page/1-introduction/Introduction.tsx
@@ -1,7 +1,20 @@
 import BgSrc from "@/assets/images/main/introduction.png"
+import useAuthStore from "@/shared/api/use-auth-store"
 import { Button, Vstack } from "@/shared/components"
+import { useNavigate } from "@tanstack/react-router"
 
 const Introduction = () => {
+  const accessToken = useAuthStore((state) => state.accessToken)
+  const navigate = useNavigate()
+  const handleFindScentClick = () => {
+    if (!accessToken) {
+      navigate({ to: "/login" })
+      return
+    }
+
+    navigate({ to: "/find-scent" })
+  }
+
   return (
     <Vstack
       gap="2xl"
@@ -25,7 +38,7 @@ const Introduction = () => {
           <p>공간을 완벽하게 마무리 해줄 향기를 찾아낼게요.</p>
         </Vstack>
       </Vstack>
-      <Button size="sm" className="z-10">
+      <Button size="sm" className="z-10" onClick={handleFindScentClick}>
         나의 마지막 조각 찾기
       </Button>
     </Vstack>

--- a/src/features/_wide.index/page/2-find-your-scent/FindYourScent.tsx
+++ b/src/features/_wide.index/page/2-find-your-scent/FindYourScent.tsx
@@ -1,14 +1,29 @@
 import Find1ImageSrc from "@/assets/images/main/find1.png"
 import Find2ImageSrc from "@/assets/images/main/find2.png"
 import Find3ImageSrc from "@/assets/images/main/find3.png"
+import useAuthStore from "@/shared/api/use-auth-store"
 import HOrVStack from "@/shared/components/layouts/HOrVStack/HOrVStack"
+import { useNavigate, type LinkProps } from "@tanstack/react-router"
 import SectionVstack from "../section-container/SectionContainer"
 import TitleSection from "../title-section/TitleSection"
 import CardWithImage from "./card-with-image/CardWithImage"
 
+type NavigationPathname = LinkProps["to"]
 const FindYourScent = () => {
   // TODO: 뷰포트 좁아지면 그리드를 Vstack으로 바꿔야 함
   // TODO: 이 때는 세로로 긴 상자 없이 둘 다 글 왼쪽 그림 오른쪽으로 배치해야
+  const accessToken = useAuthStore((state) => state.accessToken)
+  const navigate = useNavigate()
+
+  const handleNavigation = (to: NavigationPathname) => {
+    if (!accessToken) {
+      navigate({ to: "/login" })
+      return
+    }
+
+    navigate({ to })
+  }
+
   return (
     <SectionVstack>
       <TitleSection
@@ -26,7 +41,9 @@ const FindYourScent = () => {
               방 사진을 업로드해 보세요. AI가 채광, 컬러, 공기감을 읽어 그곳에
               머물러야 할 향기를 제안합니다.
             </CardWithImage.Description>
-            <CardWithImage.Button onClick={() => {}}>
+            <CardWithImage.Button
+              onClick={() => handleNavigation("/find-scent/photo")}
+            >
               Start
             </CardWithImage.Button>
           </CardWithImage.Content>
@@ -37,7 +54,9 @@ const FindYourScent = () => {
           <CardWithImage.Content>
             <CardWithImage.Category>Chat</CardWithImage.Category>
             <CardWithImage.Title>AI와 대화하기</CardWithImage.Title>
-            <CardWithImage.Button onClick={() => {}}>
+            <CardWithImage.Button
+              onClick={() => handleNavigation("/find-scent/chat")}
+            >
               Start
             </CardWithImage.Button>
             <CardWithImage.Description className="mt-auto">
@@ -51,12 +70,15 @@ const FindYourScent = () => {
         <CardWithImage direction="vertical" className="flex-1">
           <CardWithImage.Content>
             <CardWithImage.Category>Quiz</CardWithImage.Category>
-            <CardWithImage.Title>공간과 분위기 분석</CardWithImage.Title>
-            <CardWithImage.Button onClick={() => {}}>
+            <CardWithImage.Title>취향으로 찾기</CardWithImage.Title>
+            <CardWithImage.Button
+              onClick={() => handleNavigation("/find-scent/survey")}
+            >
               Start
             </CardWithImage.Button>
             <CardWithImage.Description className="mt-auto">
-              AI와 대화하기
+              간단한 설문과 키워드 선택을 통해 당신의 잠재된 취향을 파악합니다.
+              당신의 라이프스타일에 꼭 맞는 향기를 매칭해드려요.
             </CardWithImage.Description>
           </CardWithImage.Content>
           <CardWithImage.Image imgSrc={Find3ImageSrc} />

--- a/src/features/_wide.index/page/3-view-all-scents/ViewAllScents.tsx
+++ b/src/features/_wide.index/page/3-view-all-scents/ViewAllScents.tsx
@@ -1,9 +1,13 @@
 import { Button, Hstack } from "@/shared/components"
+import { useNavigate } from "@tanstack/react-router"
 import { Compass } from "lucide-react"
+import { handleScroll } from "../../utils/handle-scroll/handle-scroll"
 import SectionVstack from "../section-container/SectionContainer"
 import TitleSection from "../title-section/TitleSection"
 
 const ViewAllScents = () => {
+  const navigate = useNavigate()
+
   return (
     <SectionVstack className="items-center">
       <Compass size={60} className="text-text-sub" />
@@ -21,8 +25,15 @@ const ViewAllScents = () => {
         }
       />
       <Hstack gap="none">
-        <Button style="outlined">View all</Button>
-        <Button style="ghost">Scroll</Button>
+        <Button
+          style="outlined"
+          onClick={() => navigate({ to: "/scent-list" })}
+        >
+          View all
+        </Button>
+        <Button style="ghost" onClick={() => handleScroll("#main-quick-start")}>
+          Scroll
+        </Button>
       </Hstack>
     </SectionVstack>
   )

--- a/src/features/_wide.index/page/3-view-all-scents/ViewAllScents.tsx
+++ b/src/features/_wide.index/page/3-view-all-scents/ViewAllScents.tsx
@@ -1,4 +1,4 @@
-import { Button, Hstack } from "@/shared/components"
+import { Button } from "@/shared/components"
 import { useNavigate } from "@tanstack/react-router"
 import { Compass } from "lucide-react"
 import { handleScroll } from "../../utils/handle-scroll/handle-scroll"
@@ -24,17 +24,22 @@ const ViewAllScents = () => {
           </>
         }
       />
-      <Hstack gap="none">
+      <div className="grid grid-cols-2">
         <Button
           style="outlined"
+          className="justify-self-end"
           onClick={() => navigate({ to: "/scent-list" })}
         >
           View all
         </Button>
-        <Button style="ghost" onClick={() => handleScroll("#main-quick-start")}>
+        <Button
+          style="ghost"
+          onClick={() => handleScroll("#main-quick-start")}
+          className="justify-self-start"
+        >
           Scroll
         </Button>
-      </Hstack>
+      </div>
     </SectionVstack>
   )
 }

--- a/src/features/_wide.index/page/4-quick-start/QuickStart.tsx
+++ b/src/features/_wide.index/page/4-quick-start/QuickStart.tsx
@@ -1,5 +1,5 @@
 import useAuthStore from "@/shared/api/use-auth-store"
-import { Button, Hstack, RoundBox, Vstack } from "@/shared/components"
+import { Button, RoundBox, Vstack } from "@/shared/components"
 import HOrVStack from "@/shared/components/layouts/HOrVStack/HOrVStack"
 import { useNavigate } from "@tanstack/react-router"
 import {
@@ -85,15 +85,23 @@ const QuickStart = () => {
         />
       </HOrVStack>
 
-      <Hstack gap="none">
-        <Button style="outlined" onClick={handleStartClick}>
+      <div className="grid grid-cols-2">
+        <Button
+          style="outlined"
+          onClick={handleStartClick}
+          className="justify-self-end"
+        >
           Start now
         </Button>
-        <Button style="ghost" onClick={() => handleScroll("#main-faq")}>
+        <Button
+          style="ghost"
+          onClick={() => handleScroll("#main-faq")}
+          className="justify-self-start"
+        >
           Learn more
           <ChevronRight />
         </Button>
-      </Hstack>
+      </div>
     </SectionVstack>
   )
 }

--- a/src/features/_wide.index/page/4-quick-start/QuickStart.tsx
+++ b/src/features/_wide.index/page/4-quick-start/QuickStart.tsx
@@ -1,5 +1,7 @@
+import useAuthStore from "@/shared/api/use-auth-store"
 import { Button, Hstack, RoundBox, Vstack } from "@/shared/components"
 import HOrVStack from "@/shared/components/layouts/HOrVStack/HOrVStack"
+import { useNavigate } from "@tanstack/react-router"
 import {
   ChevronRight,
   Lightbulb,
@@ -7,6 +9,7 @@ import {
   Upload,
   type LucideIcon,
 } from "lucide-react"
+import { handleScroll } from "../../utils/handle-scroll/handle-scroll"
 import SectionVstack from "../section-container/SectionContainer"
 import TitleSection from "../title-section/TitleSection"
 
@@ -24,7 +27,12 @@ const QuickStartCard = ({
 }: QuickStartCardProps) => {
   // NOTE: currently just placeholder
   return (
-    <RoundBox padding="xl" radius="lg" className="bg-card w-full shadow-box">
+    <RoundBox
+      padding="xl"
+      radius="lg"
+      className="bg-card w-full shadow-box"
+      id="main-quick-start"
+    >
       <Vstack className="items-center">
         <RoundBox className="bg-gray-10">
           <Icon size={36} className="text-button" />
@@ -38,6 +46,16 @@ const QuickStartCard = ({
 }
 
 const QuickStart = () => {
+  const accessToken = useAuthStore((state) => state.accessToken)
+  const navigate = useNavigate()
+  const handleStartClick = () => {
+    if (!accessToken) {
+      navigate({ to: "/login" })
+      return
+    }
+    navigate({ to: "/find-scent" })
+  }
+
   return (
     <SectionVstack className="items-center">
       <TitleSection
@@ -68,8 +86,10 @@ const QuickStart = () => {
       </HOrVStack>
 
       <Hstack gap="none">
-        <Button style="outlined">Start now</Button>
-        <Button style="ghost">
+        <Button style="outlined" onClick={handleStartClick}>
+          Start now
+        </Button>
+        <Button style="ghost" onClick={() => handleScroll("#main-faq")}>
           Learn more
           <ChevronRight />
         </Button>

--- a/src/features/_wide.index/page/5-customer-reviews/review-carousel/ReviewCarousel.tsx
+++ b/src/features/_wide.index/page/5-customer-reviews/review-carousel/ReviewCarousel.tsx
@@ -54,7 +54,7 @@ const ReviewCarousel = () => {
       <Hstack className="justify-start overflow-x-hidden pb-sm">
         {reviewsInMain.map((review) => (
           <ReviewCardInMain
-            key={review.id}
+            key={`${review.type}_${review.id}`}
             reviewInMain={review}
             index={index}
           />

--- a/src/features/_wide.index/page/6-faq/FAQ.tsx
+++ b/src/features/_wide.index/page/6-faq/FAQ.tsx
@@ -8,7 +8,7 @@ import { Button, Vstack } from "@/shared/components"
 import SectionVstack from "../section-container/SectionContainer"
 const FAQ = () => {
   return (
-    <SectionVstack className="items-center">
+    <SectionVstack className="items-center" id="main-faq">
       <Vstack className="items-center">
         <h2 className="text-lg font-bold">자주 묻는 질문</h2>
         <p className="text-text-sub">

--- a/src/features/_wide.index/page/section-container/SectionContainer.tsx
+++ b/src/features/_wide.index/page/section-container/SectionContainer.tsx
@@ -5,10 +5,11 @@ import type { ReactNode } from "react"
 type SectionVstackProps = {
   children: ReactNode
   className?: string
+  id?: string
 }
-const SectionVstack = ({ children, className }: SectionVstackProps) => {
+const SectionVstack = ({ children, className, id }: SectionVstackProps) => {
   return (
-    <Vstack gap="xl" className={clsx("px-2xl", className)}>
+    <Vstack gap="xl" className={clsx("px-2xl", className)} id={id}>
       {children}
     </Vstack>
   )

--- a/src/features/_wide.index/types/main.api.type.ts
+++ b/src/features/_wide.index/types/main.api.type.ts
@@ -4,4 +4,5 @@ export type ReviewInMain = {
   name: string // NOTE: user name
   created_at: string
   review: string
+  type: string
 }

--- a/src/features/_wide.index/utils/handle-scroll/handle-scroll.ts
+++ b/src/features/_wide.index/utils/handle-scroll/handle-scroll.ts
@@ -1,0 +1,7 @@
+export const handleScroll = (selector: string) => {
+  const quickStartDiv = document.querySelector(selector)
+  quickStartDiv.scrollIntoView({
+    behavior: "smooth",
+    block: "center",
+  })
+}

--- a/src/features/_wide.index/utils/handle-scroll/handle-scroll.ts
+++ b/src/features/_wide.index/utils/handle-scroll/handle-scroll.ts
@@ -1,5 +1,7 @@
 export const handleScroll = (selector: string) => {
   const quickStartDiv = document.querySelector(selector)
+  if (!quickStartDiv) return
+
   quickStartDiv.scrollIntoView({
     behavior: "smooth",
     block: "center",

--- a/src/features/_wide/layout/WideLayout.tsx
+++ b/src/features/_wide/layout/WideLayout.tsx
@@ -32,7 +32,7 @@ const WideLayout = () => {
           <Header />
         </ContainerForScrollbarGutter>
 
-        <FlexOneContainer isYScrollable>
+        <FlexOneContainer isYScrollable id="main-scrollable-area">
           <Container className="h-full">
             <Vstack
               gap="none"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import queryClient from "./shared/api/query-client"
 const router = createRouter({
   routeTree,
   context: { queryClient },
+  scrollToTopSelectors: ["#main-scrollable-area"],
 })
 
 declare module "@tanstack/react-router" {

--- a/src/routes/_narrow.login.tsx
+++ b/src/routes/_narrow.login.tsx
@@ -1,11 +1,12 @@
 import LoginPage from "@/features/_narrow.login/page/LoginPage"
 import { createFileRoute } from "@tanstack/react-router"
+import z from "zod"
+
+const validateSearch = z.object({
+  reason: z.string().optional(),
+})
 
 export const Route = createFileRoute("/_narrow/login")({
-  validateSearch: (search: Record<string, unknown>) => {
-    return {
-      reason: typeof search.reason === "string" ? search.reason : undefined,
-    }
-  },
+  validateSearch,
   component: LoginPage,
 })


### PR DESCRIPTION
## 📌 작업 내용

- 메인 페이지의 버튼들이 작동하게 하였습니다
- 로그인 페이지의 validateSearch 로직을 단순화하여 searchParam을 설정하지 않고도 navigate이 가능해지게 했습니다
- 메인 페이지 리뷰 캐러셀에서의 키 오류를 해결했습니다
- 페이지 전환시 가장 위로 스크롤이 되게 했습니다

## 🔗 관련 이슈

- closes #204

## 📸 스크린샷 (선택)

<img width="928" height="656" alt="image" src="https://github.com/user-attachments/assets/06e0b5f0-74dc-4794-86f3-57df18ad985b" />


## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
