### PR TITLE
fix: 모바일 환경 뷰포트 높이 대응

### DIFF
--- a/src/shared/components/layouts/FullScreen/FullScreen.tsx
+++ b/src/shared/components/layouts/FullScreen/FullScreen.tsx
@@ -10,7 +10,7 @@ const FullScreen = (props: DivProps) => {
     <div
       {...rest}
       className={clsx(
-        "size-screen max-h-screen max-w-screen overflow-hidden",
+        "size-screen max-h-dvh max-w-screen overflow-hidden",
         className
       )}
     >


### PR DESCRIPTION
## 📌 작업 내용

- 모바일 환경에서도 내브바가 모두 보이게 수정

## 🔗 관련 이슈

- closes #251

## 📸 스크린샷 (선택)

<img width="1512" height="911" alt="image" src="https://github.com/user-attachments/assets/3bdcdcf6-52bf-47f8-ba9b-d464bbdb4f54" />


[https://test-mobile-full-height.vercel.app/](https://test-mobile-full-height.vercel.app/) 에서 같은 로직을 적용했습니다.
모바일로 해당 페이지에 들어가셔서 테스트해보실 수 있습니다

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
