### PR TITLE
fix: 회원가입에서 이메일, 전화번호 인증 확인을 안 하면 유효성 오류 던지게 하기

### DIFF
--- a/src/features/_narrow.find-email/page/use-find-email/use-find-email.ts
+++ b/src/features/_narrow.find-email/page/use-find-email/use-find-email.ts
@@ -16,7 +16,7 @@ const findEmailSchema = z
   })
   .refine((data) => data.sms_uuid_token, {
     message: "확인 버튼을 눌러 전화번호 인증코드를 확인해주세요",
-    path: ["email_token"],
+    path: ["phone_token"],
   })
 
 type FindEmailSchema = z.input<typeof findEmailSchema>

--- a/src/features/_narrow.signup/page/use-signup/use-signup.ts
+++ b/src/features/_narrow.signup/page/use-signup/use-signup.ts
@@ -6,35 +6,44 @@ import { useForm } from "react-hook-form"
 import z from "zod"
 import useSignupStore from "../../store/use-signup-store"
 
-const signupSchema = z.object({
-  email: z
-    .string()
-    .min(1, "이메일을 입력해주세요")
-    .email("올바른 이메일 형식으로 입력해주세요"),
-  email_token: z
-    .string()
-    .min(6, "6자리의 인증번호를 입력해주세요")
-    .max(6, "6자리의 인증번호를 입력해주세요"),
-  email_uuid_token: z.string().optional(),
-  password: z
-    .string()
-    .min(1, "비밀번호를 입력해주세요")
-    .regex(
-      /^(?=.*[A-Za-z])(?=.*\d).{8,}$/,
-      "영문과 숫자를 포함해 8자리 이상을 입력해주세요"
-    ),
-  name: z.string().min(1, "이름을 입력해주세요"),
-  phone_number: z.string().min(1, "전화번호를 입력해주세요"),
-  phone_token: z
-    .string()
-    .min(6, "6자리의 인증번호를 입력해주세요")
-    .max(6, "6자리의 인증번호를 입력해주세요"),
-  sms_uuid_token: z.string().optional(),
-  birthday: z
-    .string()
-    .min(8, "8자리의 생년월일을 입력해주세요")
-    .max(8, "8자리의 생년월일을 입력해주세요"),
-})
+const signupSchema = z
+  .object({
+    email: z
+      .string()
+      .min(1, "이메일을 입력해주세요")
+      .email("올바른 이메일 형식으로 입력해주세요"),
+    email_token: z
+      .string()
+      .min(6, "6자리의 인증번호를 입력해주세요")
+      .max(6, "6자리의 인증번호를 입력해주세요"),
+    email_uuid_token: z.string().optional(),
+    password: z
+      .string()
+      .min(1, "비밀번호를 입력해주세요")
+      .regex(
+        /^(?=.*[A-Za-z])(?=.*\d).{8,}$/,
+        "영문과 숫자를 포함해 8자리 이상을 입력해주세요"
+      ),
+    name: z.string().min(1, "이름을 입력해주세요"),
+    phone_number: z.string().min(1, "전화번호를 입력해주세요"),
+    phone_token: z
+      .string()
+      .min(6, "6자리의 인증번호를 입력해주세요")
+      .max(6, "6자리의 인증번호를 입력해주세요"),
+    sms_uuid_token: z.string().optional(),
+    birthday: z
+      .string()
+      .min(8, "8자리의 생년월일을 입력해주세요")
+      .max(8, "8자리의 생년월일을 입력해주세요"),
+  })
+  .refine((data) => data.email_uuid_token, {
+    message: "확인 버튼을 눌러 이메일 인증코드를 확인해주세요",
+    path: ["email_token"],
+  })
+  .refine((data) => data.sms_uuid_token, {
+    message: "확인 버튼을 눌러 전화번호 인증코드를 확인해주세요",
+    path: ["phone_token"],
+  })
 
 export type SignupSchema = z.input<typeof signupSchema>
 


### PR DESCRIPTION
## 📌 작업 내용

- 이메일, 전화번호 인증 확인을 하지 않은 상태에서는 submit이 안 되도록 유효성 검사에 uuid token 존재여부 확인을 넣었습니다

## 🔗 관련 이슈

- closes #259

## 📸 스크린샷 (선택)
<img width="927" height="841" alt="image" src="https://github.com/user-attachments/assets/5f0fcf5a-274d-499c-8b2a-261aaf8db5bd" />


## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
