### PR TITLE
feat: 뒤로가기 정책 정리 

### DIFF
--- a/src/features/chat/page/chat-header/ChatHeader.tsx
+++ b/src/features/chat/page/chat-header/ChatHeader.tsx
@@ -1,16 +1,9 @@
 import { BackButton } from "@/shared/components"
-import { useNavigate } from "@tanstack/react-router"
 
 const ChatHeader = () => {
-  const navigate = useNavigate()
-
-  const handleBack = () => {
-    navigate({ to: "/find-scent" })
-  }
-
   return (
     <header className=" w-full flex items-center border-b border-border px-lg py-md gap-lg">
-      <BackButton onClick={handleBack} />
+      <BackButton fallbackPath="/find-scent" mode="fallback" />
       <div>
         <h1 className="font-extrabold text-[20px]">대화로 향기 찾기</h1>
         <p className="font-light text-text-sub">

--- a/src/features/keyword/page/ScentKeyword.tsx
+++ b/src/features/keyword/page/ScentKeyword.tsx
@@ -45,10 +45,6 @@ const ScentKeyword = () => {
     })
   }
 
-  const handleBack = () => {
-    navigate({ to: "/find-scent" })
-  }
-
   const handleClearKeywords = () => {
     setSelectedKeywords([])
   }
@@ -105,7 +101,7 @@ const ScentKeyword = () => {
           title="나만의 향 찾기"
           description={`지금 가장 끌리는 무드를 선택해 보세요
 당신의 취향을 담은 향기를 큐레이션해 드립니다`}
-          backButton={<BackButton onClick={handleBack} />}
+          backButton={<BackButton fallbackPath="/find-scent" mode="fallback" />}
         />
 
         <KeywordSelectionSection

--- a/src/features/photo/page/ScentPhoto.tsx
+++ b/src/features/photo/page/ScentPhoto.tsx
@@ -33,10 +33,6 @@ const ScentPhoto = () => {
 
   const hasImage = Boolean(selectedFile)
 
-  const handleBack = () => {
-    navigate({ to: "/find-scent" })
-  }
-
   const handleAnalyzeImage = async () => {
     if (!selectedFile) {
       return
@@ -83,7 +79,7 @@ const ScentPhoto = () => {
         <PageIntro
           title="사진을 분석하여 향기를 찾습니다"
           description="이미지를 업로드하거나 직접 촬영하면 AI가 최적의 향기를 매칭합니다."
-          backButton={<BackButton onClick={handleBack} />}
+          backButton={<BackButton fallbackPath="/find-scent" mode="fallback" />}
         />
 
         <PhotoUploadSection

--- a/src/features/result/page/ResultPage.tsx
+++ b/src/features/result/page/ResultPage.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/shared/components"
 
 import type { AnalysisResult, ResultType } from "@/shared/types"
-import { useNavigate } from "@tanstack/react-router"
 import { useMemo } from "react"
 import { useAnalysisDetailQuery } from "../../../shared/hooks/useAnalysisDetailQuery"
 import ResultStateLayout from "./result-state-layout/ResultStateLayout"
@@ -25,8 +24,6 @@ type ResultPageProps = {
 }
 
 const ResultPage = ({ resultId, type }: ResultPageProps) => {
-  const navigate = useNavigate()
-
   const {
     data: fetchedResult,
     isLoading,
@@ -47,10 +44,6 @@ const ResultPage = ({ resultId, type }: ResultPageProps) => {
       type,
     } as AnalysisResult
   }, [fetchedResult, type])
-
-  const handleBack = () => {
-    navigate({ to: "/my-page" })
-  }
 
   if (!Number.isFinite(resultId)) {
     return (
@@ -95,7 +88,7 @@ const ResultPage = ({ resultId, type }: ResultPageProps) => {
           <PageIntro
             title="당신을 위한 향기 추천 결과"
             description="당신의 취향과 정보를 분석하여, 가장 잘어울리는 향기를 찾았습니다"
-            backButton={<BackButton onClick={handleBack} />}
+            backButton={<BackButton fallbackPath="/my-page" mode="fallback" />}
           />
 
           <TopCardSection result={result} type={type} />

--- a/src/features/review/page/Review.tsx
+++ b/src/features/review/page/Review.tsx
@@ -46,16 +46,26 @@ export const Review = () => {
     )
   }
 
-  const handleBack = () => {
-    navigate({ to: "/find-scent" })
-  }
-
   return (
     <Vstack className="gap-lg px-10 py-16">
       <PageIntro
         title="소중한 의견을 들려주세요"
         description="여러분의 소중한 피드백은 추천 서비스의 정확도를 높이는 데 큰 도움이 됩니다."
-        backButton={<BackButton onClick={handleBack} />}
+        backButton={
+          <BackButton
+            onClick={() =>
+              navigate({
+                to: "/find-scent/result/$resultId",
+                params: {
+                  resultId: String(resultId),
+                },
+                search: {
+                  type: search.type ?? "image",
+                },
+              })
+            }
+          />
+        }
       />
 
       <RoundBox className="mt-10 border border-border bg-white" padding="xl">

--- a/src/features/scent-detail/ScentDetail.tsx
+++ b/src/features/scent-detail/ScentDetail.tsx
@@ -8,7 +8,7 @@ import {
   Vstack,
 } from "@/shared/components"
 
-import { useNavigate, useSearch } from "@tanstack/react-router"
+import { useSearch } from "@tanstack/react-router"
 import { useDetailQuery } from "./hooks/useDetailQuery"
 
 import BottomCard from "./page/sections/bottom-section/BottomCard"
@@ -20,7 +20,6 @@ export const ScentDetail = () => {
   const { id } = useSearch({ from: "/_wide/scent-detail" })
   const scentId = Number(id)
 
-  const navigate = useNavigate()
   const { data, isLoading, error } = useDetailQuery(scentId)
 
   const scent = data?.data
@@ -36,8 +35,7 @@ export const ScentDetail = () => {
         className="min-h-screen max-w-container-xl bg-surface-default"
       >
         <Vstack className="mx-2xl">
-          <BackButton onClick={() => navigate({ to: "/scent-list" })} />
-
+          <BackButton fallbackPath="/scent-list" />
           {isLoading ? (
             <LoadingState />
           ) : isInvalid ? (

--- a/src/features/survey/page/ScentSurvey.tsx
+++ b/src/features/survey/page/ScentSurvey.tsx
@@ -24,10 +24,6 @@ const ScentSurvey = () => {
   const navigate = useNavigate()
   const [answers, setAnswers] = useState<Record<number, number>>({})
 
-  const handleBack = () => {
-    navigate({ to: "/find-scent" })
-  }
-
   const handleChangeAnswer = ({
     index,
     value,
@@ -85,7 +81,7 @@ const ScentSurvey = () => {
           title="나만의 향 찾기"
           description={`각 질문에 대해 선호하는 방향을 선택해 주세요
 드래그하거나 점을 탭하여 선택할 수 있습니다`}
-          backButton={<BackButton onClick={handleBack} />}
+          backButton={<BackButton fallbackPath="/find-scent" mode="fallback" />}
         />
 
         {questions.map((item, index) => (

--- a/src/shared/components/back-button/BackButton.stories.tsx
+++ b/src/shared/components/back-button/BackButton.stories.tsx
@@ -9,8 +9,21 @@ const meta = {
     layout: "centered",
   },
   tags: ["autodocs"],
+  argTypes: {
+    mode: {
+      control: "radio",
+      options: ["history", "fallback"],
+    },
+    fallbackPath: {
+      control: "text",
+    },
+    onClick: {
+      action: "clicked",
+    },
+  },
   args: {
-    onClick: () => {},
+    fallbackPath: "/",
+    mode: "history",
   },
 } satisfies Meta<typeof BackButton>
 
@@ -19,3 +32,16 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
+
+export const FallbackMode: Story = {
+  args: {
+    fallbackPath: "/find-scent",
+    mode: "fallback",
+  },
+}
+
+export const WithCustomClick: Story = {
+  args: {
+    onClick: () => {},
+  },
+}

--- a/src/shared/components/back-button/BackButton.tsx
+++ b/src/shared/components/back-button/BackButton.tsx
@@ -1,14 +1,37 @@
+import { useRouter } from "@tanstack/react-router"
 import { ChevronLeft } from "lucide-react"
 
 type BackButtonProps = {
   onClick?: () => void
+  fallbackPath?: string
+  mode?: "history" | "fallback"
 }
 
-const BackButton = ({ onClick }: BackButtonProps) => {
+const BackButton = ({
+  onClick,
+  fallbackPath = "/",
+  mode = "history",
+}: BackButtonProps) => {
+  const router = useRouter()
+
+  const handleClick = () => {
+    if (onClick) {
+      onClick()
+      return
+    }
+
+    if (mode === "history" && window.history.length > 1) {
+      window.history.back()
+      return
+    }
+
+    router.navigate({ to: fallbackPath })
+  }
+
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={handleClick}
       aria-label="뒤로가기"
       className="flex cursor-pointer mt-1 md:mt-0 h-6 w-6 md:h-9 md:w-9 items-center justify-center rounded-full border border-border bg-card transition-all duration-200 hover:bg-button hover:text-surface-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-button focus-visible:ring-offset-2"
     >


### PR DESCRIPTION
## 📌 작업 내용

- 공통 BackButton에 `fallbackPath`, `mode` props를 추가했습니다.
- 페이지 성격에 따라 뒤로가기 이동 정책을 정리했습니다.
- 기능/결과 페이지는 `/find-scent`로 이동하도록 통일했습니다.
- 리뷰 작성 페이지는 `resultId`, `type` 기반으로 기존 결과 상세 페이지로 복귀하도록 처리했습니다.
- 향기 디테일 페이지는 진입점이 많아 history 기반 뒤로가기를 유지했습니다.
- BackButton Storybook을 현재 props 기준으로 업데이트했습니다.

## 🔗 관련 이슈

- closes #255

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인