### PR TITLE
feat: 유저 가드 설정 

### DIFF
--- a/src/features/chat/page/ScentChat.tsx
+++ b/src/features/chat/page/ScentChat.tsx
@@ -4,6 +4,7 @@ import {
   RoundBox,
   Vstack,
 } from "@/shared/components"
+import { useUserGuard } from "@/shared/hooks/useUserGuard"
 import { useEffect, useState } from "react"
 import { useCreateChatSession } from "../hooks/useCreateChatSession"
 import { useRetryChatRecommendationMutation } from "../hooks/useRetryChatRecommendation"
@@ -23,6 +24,8 @@ import ChatInput from "./chat-input/ChatInput"
 import ChatList from "./chat-list/ChatList"
 
 const ScentChat = () => {
+  useUserGuard()
+
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>(messages)
   const [sessionId, setSessionId] = useState<number | null>(null)
 

--- a/src/features/keyword/page/ScentKeyword.tsx
+++ b/src/features/keyword/page/ScentKeyword.tsx
@@ -8,6 +8,7 @@ import {
   Vstack,
 } from "@/shared/components"
 import LoadingState from "@/shared/components/loading-state/LoadingState"
+import { useUserGuard } from "@/shared/hooks/useUserGuard"
 import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
 import {
@@ -21,6 +22,8 @@ import SelectedKeywordSection from "./selected-keyword-section/SelectedKeywordSe
 const MIN_KEYWORD_COUNT = 3
 
 const ScentKeyword = () => {
+  useUserGuard()
+
   const navigate = useNavigate()
   const { data: questions, isPending, isError } = useKeywordQuestions()
   const [selectedKeywords, setSelectedKeywords] = useState<SelectedKeyword[]>(

--- a/src/features/photo/page/ScentPhoto.tsx
+++ b/src/features/photo/page/ScentPhoto.tsx
@@ -6,6 +6,7 @@ import {
   PageIntro,
   Vstack,
 } from "@/shared/components"
+import { useUserGuard } from "@/shared/hooks/useUserGuard"
 import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
 import { uploadImageToS3 } from "../api/image-analysis.api"
@@ -16,6 +17,7 @@ import PhotoTipsSection from "./photo-tips-section/PhotoTipsSection"
 import PhotoUploadSection from "./photo-upload-section/PhotoUploadSection"
 
 const ScentPhoto = () => {
+  useUserGuard()
   const [step, setStep] = useState<MobilePhotoStep>("select")
   const [previewUrl, setPreviewUrl] = useState("")
   const [selectedFile, setSelectedFile] = useState<File | null>(null)

--- a/src/features/result/page/ResultPage.tsx
+++ b/src/features/result/page/ResultPage.tsx
@@ -9,6 +9,7 @@ import {
   Vstack,
 } from "@/shared/components"
 
+import { useUserGuard } from "@/shared/hooks/useUserGuard"
 import type { AnalysisResult, ResultType } from "@/shared/types"
 import { useMemo } from "react"
 import { useAnalysisDetailQuery } from "../../../shared/hooks/useAnalysisDetailQuery"
@@ -24,6 +25,8 @@ type ResultPageProps = {
 }
 
 const ResultPage = ({ resultId, type }: ResultPageProps) => {
+  useUserGuard()
+
   const {
     data: fetchedResult,
     isLoading,

--- a/src/features/review/page/Review.tsx
+++ b/src/features/review/page/Review.tsx
@@ -5,12 +5,14 @@ import {
   RoundBox,
   Vstack,
 } from "@/shared/components"
+import { useUserGuard } from "@/shared/hooks/useUserGuard"
 import { useNavigate, useSearch } from "@tanstack/react-router"
 import { useState } from "react"
 import { useCreateReviewMutation } from "../hooks/useCreateReviewMutation"
 import ReviewStarRating from "./review-star-rating/ReviewStatRating"
 
 export const Review = () => {
+  useUserGuard()
   const navigate = useNavigate()
 
   const search = useSearch({ from: "/_wide/review" }) as {

--- a/src/features/survey/page/ScentSurvey.tsx
+++ b/src/features/survey/page/ScentSurvey.tsx
@@ -6,6 +6,7 @@ import {
   Vstack,
 } from "@/shared/components"
 import LoadingState from "@/shared/components/loading-state/LoadingState"
+import { useUserGuard } from "@/shared/hooks/useUserGuard"
 import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
 import {
@@ -17,6 +18,8 @@ import PreferenceSlider from "./preference-slider/PreferenceSlider"
 const DEFAULT_SURVEY_VALUE = 2
 
 const ScentSurvey = () => {
+  useUserGuard()
+
   const { data: questions, isPending, isError } = useSurveyQuestions()
   const { mutateAsync: submitSurveyResult, isPending: isSubmitting } =
     useSurveyResultMutation()

--- a/src/shared/hooks/useUserGuard.ts
+++ b/src/shared/hooks/useUserGuard.ts
@@ -1,0 +1,23 @@
+import useAuthStore from "@/shared/api/use-auth-store"
+import { useNavigate } from "@tanstack/react-router"
+import { useEffect } from "react"
+
+export const useUserGuard = () => {
+  const navigate = useNavigate()
+  const accessToken = useAuthStore((state) => state.accessToken)
+
+  useEffect(() => {
+    if (accessToken) {
+      return
+    }
+
+    // TODO: 라우트 구조 정리 후 TanStack Router beforeLoad 또는 _auth 라우트 그룹 방식으로 전환 검토
+    navigate({
+      to: "/login",
+      search: {
+        reason: "unauthorized",
+      },
+      replace: true,
+    })
+  }, [accessToken, navigate])
+}


### PR DESCRIPTION
## 📌 작업 내용

- `accessToken` 기준 유저가드 공통 훅을 추가했습니다.
- 비로그인 상태에서 보호 페이지 접근 시 로그인 페이지로 이동하도록 적용했습니다.
- 기능 페이지, 결과 페이지, 리뷰 페이지 등 로그인이 필요한 페이지에 유저가드를 적용했습니다.
- 로그인 페이지의 `reason=unauthorized` 토스트 안내 흐름을 활용했습니다.

## 🔗 관련 이슈

- closes #254

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
