### PR TITLE
feat: 서버 에러별 메시지 매핑

### DIFF
--- a/src/features/_narrow.signup/page/signup-modals/signup-error-modal/SignupErrorModal.tsx
+++ b/src/features/_narrow.signup/page/signup-modals/signup-error-modal/SignupErrorModal.tsx
@@ -1,32 +1,7 @@
 import useSignupStore from "@/features/_narrow.signup/store/use-signup-store"
 import { Modal } from "@/shared/components"
 import ModalContent from "@/shared/components/modal-content/ModalContent"
-import { ERROR_CODE_TO_MESSAGE } from "@/shared/constants/error-code-to-message"
-import type { AxiosError } from "axios"
-
-const parseErrorMessage = (error: AxiosError<{ code: string }>): string => {
-  if (!error?.response?.data)
-    throw new Error("---- 이 전에 에러 데이터를 가드해야 합니다")
-
-  const errorCode = error.response.data.code
-  const errorMessage = ERROR_CODE_TO_MESSAGE[errorCode]
-  if (errorMessage) return errorMessage
-
-  const detailKeyCandidates = Object.keys(error.response.data).filter((key) =>
-    key.includes("detail")
-  )
-  if (detailKeyCandidates.length === 0) return "알 수 없는 오류가 발생했습니다"
-  const detailKey = detailKeyCandidates[0]
-  if (!detailKey) throw new Error("---- UNREACHABLE")
-
-  const value = error.response.data[detailKey]
-  if (typeof value === "string") return value
-  if (Array.isArray(value)) return value[0]
-  if (typeof value === "object" && value !== null)
-    return Object.entries(value)[0][1] as string
-
-  return "알 수 없는 오류가 발생했습니다"
-}
+import { parseErrorMessage } from "@/shared/utils/parse-error-message"
 
 const SignupErrorModal = () => {
   const modalKey = useSignupStore((state) => state.modalKey)

--- a/src/features/_narrow.signup/page/signup-modals/signup-error-modal/SignupErrorModal.tsx
+++ b/src/features/_narrow.signup/page/signup-modals/signup-error-modal/SignupErrorModal.tsx
@@ -1,6 +1,32 @@
 import useSignupStore from "@/features/_narrow.signup/store/use-signup-store"
 import { Modal } from "@/shared/components"
 import ModalContent from "@/shared/components/modal-content/ModalContent"
+import { ERROR_CODE_TO_MESSAGE } from "@/shared/constants/error-code-to-message"
+import type { AxiosError } from "axios"
+
+const parseErrorMessage = (error: AxiosError<{ code: string }>): string => {
+  if (!error?.response?.data)
+    throw new Error("---- 이 전에 에러 데이터를 가드해야 합니다")
+
+  const errorCode = error.response.data.code
+  const errorMessage = ERROR_CODE_TO_MESSAGE[errorCode]
+  if (errorMessage) return errorMessage
+
+  const detailKeyCandidates = Object.keys(error.response.data).filter((key) =>
+    key.includes("detail")
+  )
+  if (detailKeyCandidates.length === 0) return "알 수 없는 오류가 발생했습니다"
+  const detailKey = detailKeyCandidates[0]
+  if (!detailKey) throw new Error("---- UNREACHABLE")
+
+  const value = error.response.data[detailKey]
+  if (typeof value === "string") return value
+  if (Array.isArray(value)) return value[0]
+  if (typeof value === "object" && value !== null)
+    return Object.entries(value)[0][1] as string
+
+  return "알 수 없는 오류가 발생했습니다"
+}
 
 const SignupErrorModal = () => {
   const modalKey = useSignupStore((state) => state.modalKey)
@@ -11,7 +37,7 @@ const SignupErrorModal = () => {
 
   if (!signupError?.response?.data) return null
 
-  const errorMessage = Object.entries(signupError.response.data)[0][1]
+  const errorMessage = parseErrorMessage(signupError)
 
   return (
     <Modal isOpen={modalKey === "error"} onClose={() => setModalKey(null)}>

--- a/src/features/_narrow.signup/page/use-signup/use-signup.ts
+++ b/src/features/_narrow.signup/page/use-signup/use-signup.ts
@@ -55,7 +55,7 @@ const useSignup = () => {
       plainInstance.post("accounts/signup", body),
     onSuccess: () => setModalKey("success"),
     onError: () => setModalKey("error"),
-    onSettled: (_data, error: AxiosError | null) => {
+    onSettled: (_data, error: AxiosError<{ code: string }> | null) => {
       setSignupError(error)
     },
   })

--- a/src/features/_narrow.signup/store/use-signup-store.ts
+++ b/src/features/_narrow.signup/store/use-signup-store.ts
@@ -5,8 +5,8 @@ type SignupStoreState = {
   modalKey: "success" | "error" | null
   setModalKey: (modelKey: "success" | "error" | null) => void
 
-  signupError: AxiosError | null
-  setSignupError: (signupError: AxiosError | null) => void
+  signupError: AxiosError<{ code: string }> | null
+  setSignupError: (signupError: AxiosError<{ code: string }> | null) => void
 }
 
 const useSignupStore = create<SignupStoreState>()((set) => ({

--- a/src/shared/constants/error-code-to-message.ts
+++ b/src/shared/constants/error-code-to-message.ts
@@ -1,0 +1,9 @@
+export const ERROR_CODE_TO_MESSAGE = {
+  USER_ALREADY_EXISTS: "이미 가입되었습니다",
+  INVALID_EMAIL_FORMAT: "이메일 형식이 올바르지 않습니다",
+  INVALID_PHONE_FORMAT: "전화번호 형식이 올바르지 않습니다",
+  VALIDATION_ERROR: "입력값이 유효하지 않습니다", //NOTE:	일반적인 필드 검증 실패
+  NOT_AUTHENTICATED: "로그인이 필요합니다",
+  AUTHENTICATION_FAILED: "아이디 혹은 비밀번호가 잘못 입력되었습니다",
+  NOT_FOUND: "요청하신 것을 찾을 수 없습니다",
+} as const

--- a/src/shared/constants/error-code-to-message.ts
+++ b/src/shared/constants/error-code-to-message.ts
@@ -1,5 +1,5 @@
 export const ERROR_CODE_TO_MESSAGE = {
-  USER_ALREADY_EXISTS: "이미 가입되었습니다",
+  USER_ALREADY_EXISTS: "이미 가입된 이메일 혹은 전화번호입니다",
   INVALID_EMAIL_FORMAT: "이메일 형식이 올바르지 않습니다",
   INVALID_PHONE_FORMAT: "전화번호 형식이 올바르지 않습니다",
   VALIDATION_ERROR: "입력값이 유효하지 않습니다", //NOTE:	일반적인 필드 검증 실패

--- a/src/shared/utils/parse-error-message.ts
+++ b/src/shared/utils/parse-error-message.ts
@@ -1,0 +1,29 @@
+import type { AxiosError } from "axios"
+import { ERROR_CODE_TO_MESSAGE } from "../constants/error-code-to-message"
+
+export const parseErrorMessage = <T extends AxiosError<{ code: string }>>(
+  error: T
+): string => {
+  if (!error?.response?.data)
+    throw new Error("---- 이 전에 에러 데이터를 가드해야 합니다")
+
+  const errorCode = error.response.data
+    .code as keyof typeof ERROR_CODE_TO_MESSAGE
+  const errorMessage = ERROR_CODE_TO_MESSAGE[errorCode]
+  if (errorMessage) return errorMessage
+
+  const detailKeyCandidates = Object.keys(error.response.data).filter((key) =>
+    key.includes("detail")
+  )
+  if (detailKeyCandidates.length === 0) return "알 수 없는 오류가 발생했습니다"
+  const detailKey = detailKeyCandidates[0] as keyof typeof error.response.data
+  if (!detailKey) throw new Error("---- UNREACHABLE")
+
+  const value = error.response.data[detailKey]
+  if (typeof value === "string") return value
+  if (Array.isArray(value)) return value[0]
+  if (typeof value === "object" && value !== null)
+    return Object.entries(value)[0][1] as string
+
+  return "알 수 없는 오류가 발생했습니다"
+}


### PR DESCRIPTION
## 📌 작업 내용

- 에러 메시지 파싱 로직을 만들었습니다
- 회원가입 실패 모달에서 해당 메시지를 출력합니다
- 회원가입 이외의 페이지에서의 오류 핸들링은 새 이슈에서 다루겠습니다

## 🔗 관련 이슈

- closes #264

## 📸 스크린샷 (선택)

<img width="529" height="346" alt="image" src="https://github.com/user-attachments/assets/ae2a2463-c09b-4cf3-be41-844c3b7a8f04" />


## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
