### PR TITLE
fix: 메인페이지 글들 줄바꿈 되어도 가운데 정렬 되도록 수정

### DIFF
--- a/src/features/_wide.index/page/6-faq/FAQ.tsx
+++ b/src/features/_wide.index/page/6-faq/FAQ.tsx
@@ -9,7 +9,7 @@ import SectionVstack from "../section-container/SectionContainer"
 const FAQ = () => {
   return (
     <SectionVstack className="items-center" id="main-faq">
-      <Vstack className="items-center">
+      <Vstack className="items-center text-center">
         <h2 className="text-lg font-bold">자주 묻는 질문</h2>
         <p className="text-text-sub">
           Fragmnt 서비스에 대해 궁금한 점을 확인해보세요.

--- a/src/features/_wide.index/page/title-section/TitleSection.tsx
+++ b/src/features/_wide.index/page/title-section/TitleSection.tsx
@@ -12,7 +12,7 @@ const TitleSection = ({
   subtitle,
 }: TitleSectionProps) => {
   return (
-    <Vstack className="items-center">
+    <Vstack className="items-center text-center">
       <h2 className="text-text-sub">{smallTitle}</h2>
       <h3 className="text-xl font-bold">{bigTitle}</h3>
       {subtitle}


### PR DESCRIPTION
## 📌 작업 내용

- 메인페이지의 제목에 `text-center`를 적용했습니다

## 🔗 관련 이슈

- closes #274

## 📸 스크린샷 (선택)
<img width="380" height="396" alt="image" src="https://github.com/user-attachments/assets/b0ea0f2c-b31f-4fad-8d49-d2b395501e4b" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
