### PR TITLE
fix: my page 반응형 수정

### DIFF
--- a/src/features/my-page/pages/sections/collection-section/CollectionSection.tsx
+++ b/src/features/my-page/pages/sections/collection-section/CollectionSection.tsx
@@ -80,7 +80,7 @@ export const CollectionSection = () => {
         </h2>
 
         {hasItems ? (
-          <div className="mt-md grid grid-cols-2 gap-lg">
+          <div className="mt-md grid grid-cols-1 gap-lg sm:grid-cols-2">
             {favoriteScents.map((item) => (
               <CollectionCard
                 key={item.id}

--- a/src/features/my-page/pages/sections/collection-section/collection-card/CollectionCard.tsx
+++ b/src/features/my-page/pages/sections/collection-section/collection-card/CollectionCard.tsx
@@ -30,9 +30,9 @@ const CollectionCard = ({
       onClick={onClick}
       role="button"
       tabIndex={0}
-      className="flex h-[440px] w-full flex-col overflow-hidden rounded-lg border border-border bg-card transition-shadow duration-200 hover:shadow-md"
+      className="flex w-full flex-col overflow-hidden rounded-lg border border-border bg-card transition-shadow duration-200 hover:shadow-md"
     >
-      <div className="flex items-center justify-center h-[315px] w-full overflow-hidden">
+      <div className="flex items-center justify-center aspect-square w-full overflow-hidden">
         {imageSrc && !isError ? (
           <img
             src={imageSrc}
@@ -48,7 +48,7 @@ const CollectionCard = ({
         <div className="flex justify-between">
           <div>
             <p className="text-sm font-light text-text-sub">{category}</p>
-            <h3 className="text-[20px] font-bold">{title}</h3>
+            <h3 className="text-lg font-bold">{title}</h3>
           </div>
           <button
             type="button"

--- a/src/features/my-page/pages/sections/history-section/history-card/HistoryCard.tsx
+++ b/src/features/my-page/pages/sections/history-section/history-card/HistoryCard.tsx
@@ -23,17 +23,17 @@ const HistoryCard = ({
       type="button"
       onClick={onClick}
       className={cn(
-        "flex w-full h-[120px] items-center gap-4 rounded-md border border-primary bg-white px-md py-md text-left shadow-md transition-all",
+        "flex w-full min-h-[96px] items-center gap-3 rounded-md border border-primary bg-white px-md py-md text-left shadow-md transition-all sm:min-h-[120px] sm:gap-4",
         "hover:bg-gray-5 hover:shadow-lg",
         className
       )}
     >
-      <div className="flex  aspect-square shrink-0 items-left justify-left overflow-hidden rounded-lg bg-disabled">
+      <div className="flex size-18 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-disabled sm:size-25">
         {imageSrc && !isError ? (
           <img
             src={imageSrc}
             alt={imageAlt}
-            className="block size-25 object-cover"
+            className="h-full w-full object-cover"
             onError={() => setIsError(true)}
           />
         ) : (
@@ -42,13 +42,13 @@ const HistoryCard = ({
       </div>
 
       <div className="flex-1 min-w-0 gap-md">
-        <div className="flex min-w-0 items-center gap-sm">
-          <h3 className="min-w-0 truncate text-lg font-bold leading-none text-text-primary">
+        <div className="flex min-w-0 flex-col items-start gap-xs sm:flex-row sm:items-center sm:gap-sm">
+          <h3 className="min-w-0 truncate text-md font-bold leading-none text-text-primary sm:text-lg">
             {title}
           </h3>
 
           {badgeText && (
-            <span className="inline-flex h-6 shrink-0 items-center rounded-full bg-badge px-2 text-sm font-semibold text-text-description">
+            <span className="inline-flex h-6 shrink-0 items-center rounded-full bg-badge px-2 text-sm font-semibold text-text-description whitespace-nowrap">
               {badgeText}
             </span>
           )}

--- a/src/features/my-page/pages/user-section/UserSection.tsx
+++ b/src/features/my-page/pages/user-section/UserSection.tsx
@@ -170,7 +170,7 @@ export const UserSection = ({ user, className }: UserSectionProps) => {
         </button>
       </div>
 
-      <div className="grid grid-cols-2 gap-sm">
+      <div className="grid grid-cols-1 gap-sm md:grid-cols-2">
         {isEditing ? (
           <>
             <EditField

--- a/src/features/my-page/pages/user-section/UserSection.tsx
+++ b/src/features/my-page/pages/user-section/UserSection.tsx
@@ -54,10 +54,17 @@ export const UserSection = ({ user, className }: UserSectionProps) => {
   }
 
   const handleSubmit = () => {
-    mutate({
-      name: form.name,
-      birthday: form.birthday,
-    })
+    mutate(
+      {
+        name: form.name,
+        birthday: form.birthday,
+      },
+      {
+        onSuccess: () => {
+          setIsEditing(false)
+        },
+      }
+    )
   }
 
   const fileInputRef = useRef<HTMLInputElement>(null)

--- a/src/features/my-page/pages/user-section/user-card/UserCard.tsx
+++ b/src/features/my-page/pages/user-section/user-card/UserCard.tsx
@@ -28,8 +28,9 @@ const UserCard = (props: UserCardProps) => {
         {icon ?? <Mail size={18} strokeWidth={2} />}
       </div>
 
-      <div className="flex flex-col justify-center">
+      <div className="min-w-0 flex flex-1 flex-col justify-center">
         <span className="text-sm leading-none text-text-sub">{label}</span>
+
         <span className="truncate pt-xs text-md leading-none text-text-primary">
           {value}
         </span>


### PR DESCRIPTION
## 📌 작업 내용

- 개인정보 카드의 경우, 화면이 좁아지면 2열이 아닌 1열로 나열하도록 수정하였습니다.
<img width="424" height="346" alt="image" src="https://github.com/user-attachments/assets/9ba6e2ce-d17b-4300-9f6e-8aff3ce64768" />
- 그보다 더 좁아지면 말줄임표로 대응합니다.
<img width="168" height="116" alt="image" src="https://github.com/user-attachments/assets/7ad4fa8b-6137-4dd9-8016-45754b98f085" />
- 컬렉션 카드도 화면이 좁아지면 1열로 노출됩니다.
<img width="385" height="538" alt="image" src="https://github.com/user-attachments/assets/f1c9cfb2-7b66-4823-a739-cbb307d3f19c" />
- 기록의 경우 글씨가 보이지 않는 오류를 수정했습니다.
<img width="377" height="373" alt="image" src="https://github.com/user-attachments/assets/b9f0dcbb-7820-4f16-92e9-ffe23d290ade" />


## 🔗 관련 이슈

- closes #272

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
