### PR TITLE
fix: 아이폰 플렉스 박스 오류 해결

### DIFF
--- a/src/shared/components/inputs/Input/Input.tsx
+++ b/src/shared/components/inputs/Input/Input.tsx
@@ -34,7 +34,7 @@ const Input = ({
       <input
         {...rest}
         disabled={disabled}
-        className="flex-1 border-0 py-md pl-lg outline-0"
+        className="flex-1 border-0 py-md pl-lg outline-0 min-w-0"
       />
       {trailingChild}
     </Hstack>

--- a/src/shared/components/layouts/Hstack/Hstack.tsx
+++ b/src/shared/components/layouts/Hstack/Hstack.tsx
@@ -1,3 +1,4 @@
+import cn from "@/lib/utils"
 import type { DivProps } from "@/shared/types"
 import type {
   None,
@@ -5,9 +6,8 @@ import type {
 } from "@/shared/types/commonPropsTypes/commonPropsTypes"
 import { gapVariants } from "@/shared/utils/variant-to-classname"
 import { cva } from "class-variance-authority"
-import clsx from "clsx"
 
-const hstackVariants = cva("flex justify-center", {
+const hstackVariants = cva("min-w-0 flex justify-center", {
   variants: {
     gap: gapVariants,
   },
@@ -25,7 +25,7 @@ const Hstack = ({ gap = "lg", ...props }: DivProps & WithHstackProps) => {
   const { className, children, ...rest } = props
 
   return (
-    <div {...rest} className={clsx(hstackVariants({ gap }), className)}>
+    <div {...rest} className={cn(hstackVariants({ gap }), className)}>
       {children}
     </div>
   )


### PR DESCRIPTION
## 📌 작업 내용

- 아이폰에서는 기본값으로 min-width: auto로 되어 있습니다. 이를 min-width: 0으로 덮어씁니다. 

## 🔗 관련 이슈

- closes #278

## 📸 스크린샷 (선택)

<img width="3468" height="4624" alt="image" src="https://github.com/user-attachments/assets/c92eab9e-26e2-4e8f-92b7-8e9571f0c3a8" />

[포크 버전](https://forked-fe-one-piece.vercel.app/signup) 에서 미리 확인하실 수 있습니다

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
