### PR TITLE
fix: 디테일 페이지 반응형 수정 

### DIFF
--- a/src/features/scent-detail/page/sections/bottom-section/BottomCard.tsx
+++ b/src/features/scent-detail/page/sections/bottom-section/BottomCard.tsx
@@ -23,7 +23,7 @@ const BottomCard = ({
         <div className="text-lg font-bold">Recommended Places</div>
       </div>
 
-      <div className="grid w-full grid-cols-2 gap-4">
+      <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2">
         {recommendedPlaces.map((place) => (
           <PlaceCard
             key={place.name}
@@ -41,7 +41,7 @@ const BottomCard = ({
         <div className="text-lg font-bold">Similar Scents</div>
       </div>
 
-      <div className="grid w-full grid-cols-2 gap-4">
+      <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2">
         {similarScents.map((scent) => (
           <ArchiveCard
             key={scent.id}

--- a/src/features/scent-detail/page/sections/bottom-section/place-card/PlaceCard.tsx
+++ b/src/features/scent-detail/page/sections/bottom-section/place-card/PlaceCard.tsx
@@ -43,14 +43,19 @@ export default function PlaceCard({
       <div className="absolute inset-x-0 bottom-0 h-1/2 bg-linear-to-t from-black/60 via-black/20 to-transparent" />
 
       {typeof matchRate === "number" && (
-        <div className="absolute right-md top-md">
+        <div className="absolute right-sm top-sm md:right-md md:top-md">
           <Tag label={`${matchRate}% MATCH`} size="sm" variant="subtle" />
         </div>
       )}
 
-      <div className="absolute bottom-lg left-lg right-lg">
-        <h3 className="text-lg font-bold text-white">{title}</h3>
-        <p className="text-sm text-white/85 line-clamp-2">{description}</p>
+      <div className="absolute bottom-md left-md right-md md:bottom-lg md:left-lg md:right-lg">
+        <h3 className="truncate text-md font-bold text-white md:text-lg">
+          {title}
+        </h3>
+
+        <p className="line-clamp-1 text-sm text-white/85 md:line-clamp-2">
+          {description}
+        </p>
       </div>
     </div>
   )

--- a/src/features/scent-detail/page/sections/note-section/NoteCard.tsx
+++ b/src/features/scent-detail/page/sections/note-section/NoteCard.tsx
@@ -61,8 +61,8 @@ const NoteCard = ({ notes, tags, seasons }: NoteCardProps) => {
         ))}
       </div>
 
-      <div className="flex w-full justify-between gap-2xl px-2xl pt-2xl">
-        <div className="flex flex-1 flex-col gap-md">
+      <div className="flex w-full flex-col items-center gap-xl px-lg pt-2xl md:flex-row md:items-start md:justify-between md:gap-2xl md:px-2xl">
+        <div className="flex w-full flex-1 flex-col items-center gap-md md:items-start">
           <div className="flex items-center gap-2 text-lg font-bold">
             <TagIcon size={16} />
             <span>Tags</span>

--- a/src/features/scent-detail/page/sections/profile-section/ProfileCard.tsx
+++ b/src/features/scent-detail/page/sections/profile-section/ProfileCard.tsx
@@ -71,7 +71,7 @@ const ProfileCard = ({ intensity, profile }: ProfileCardProps) => {
           />
         </div>
 
-        <div className="flex h-full items-center justify-center p-sm">
+        <div className="hidden h-full items-center justify-center p-sm sm:flex">
           <div className="flex size-button-lg items-center justify-center rounded-full bg-badge font-bold text-text-primary">
             {intensity}
           </div>
@@ -79,7 +79,7 @@ const ProfileCard = ({ intensity, profile }: ProfileCardProps) => {
       </div>
 
       <div className="w-full rounded-lg border border-border bg-white p-lg">
-        <div className="grid grid-cols-2 gap-lg">
+        <div className="grid grid-cols-1 gap-lg sm:grid-cols-2">
           {metrics.map((metric) => (
             <StateBar
               key={metric.label}


### PR DESCRIPTION
## 📌 작업 내용

- 디테일 페이지를 반응형으로 수정했습니다.
  - 대부분의 grid가 화면이 좁아지면 1열로 바뀝니다.


## 🔗 관련 이슈

- closes #284

## 📸 스크린샷 (선택)
<img width="397" height="564" alt="image" src="https://github.com/user-attachments/assets/638e189b-1a03-42a1-90b2-96b02d9e2083" />
<img width="332" height="310" alt="image" src="https://github.com/user-attachments/assets/8cdf8e72-e0d8-4aa5-bf80-3dcaebb37f54" />


## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
