### PR TITLE
fix: 소설 로그인 후 access token, profile 받아오기

### DIFF
--- a/src/features/_wide.index/page/MainPage.tsx
+++ b/src/features/_wide.index/page/MainPage.tsx
@@ -1,5 +1,8 @@
 import InsertionSrc from "@/assets/images/main/insertion.png"
+import useAuthStore from "@/shared/api/use-auth-store"
 import { Vstack } from "@/shared/components"
+import { useNavigate, useSearch } from "@tanstack/react-router"
+import { useEffect } from "react"
 import Introduction from "./1-introduction/Introduction"
 import FindYourScent from "./2-find-your-scent/FindYourScent"
 import ViewAllScents from "./3-view-all-scents/ViewAllScents"
@@ -8,6 +11,22 @@ import CustomerReviews from "./5-customer-reviews/CustomerReviews"
 import FAQ from "./6-faq/FAQ"
 
 const MainPage = () => {
+  const { access_token: socialLoginAccessToken } = useSearch({ from: "/" })
+  const navigate = useNavigate()
+
+  const accessToken = useAuthStore((state) => state.accessToken)
+  const refresh = useAuthStore((state) => state.refresh)
+
+  if (socialLoginAccessToken && !accessToken) {
+    refresh()
+  }
+
+  useEffect(() => {
+    if (!socialLoginAccessToken) return
+    if (!accessToken) return
+    navigate({ to: "/" })
+  }, [socialLoginAccessToken, accessToken]) // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
     <Vstack gap="2xl" className="pb-2xl">
       <Introduction />

--- a/src/features/_wide.index/page/MainPage.tsx
+++ b/src/features/_wide.index/page/MainPage.tsx
@@ -11,7 +11,9 @@ import CustomerReviews from "./5-customer-reviews/CustomerReviews"
 import FAQ from "./6-faq/FAQ"
 
 const MainPage = () => {
-  const { access_token: socialLoginAccessToken } = useSearch({ from: "/" })
+  const { access_token: socialLoginAccessToken } = useSearch({
+    from: "__root__",
+  })
   const navigate = useNavigate()
 
   const accessToken = useAuthStore((state) => state.accessToken)

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -3,9 +3,15 @@ import DefaultErrorPage from "@/features/default-error-page/page/DefaultErrorPag
 import { NotFoundPage } from "@/features/not-found-page"
 import type { RouterContext } from "@/main"
 import { createRootRouteWithContext } from "@tanstack/react-router"
+import z from "zod"
+
+const validateSearch = z.object({
+  access_token: z.string().optional(),
+})
 
 export const Route = createRootRouteWithContext<RouterContext>()({
   component: RootLayout,
   notFoundComponent: NotFoundPage,
   errorComponent: DefaultErrorPage,
+  validateSearch,
 })

--- a/src/shared/api/use-auth-store.ts
+++ b/src/shared/api/use-auth-store.ts
@@ -2,6 +2,7 @@ import { logoutApi } from "@/features/my-page/api/user.api"
 import { create } from "zustand"
 import { createJSONStorage, persist } from "zustand/middleware"
 import type { Profile } from "../types"
+import { instance, plainInstance } from "./axios-instance"
 
 type AuthStoreState = {
   accessToken: string | null
@@ -10,6 +11,8 @@ type AuthStoreState = {
   profile: Profile | null
   setProfile: (profile: Profile | null) => void
 
+  refresh: () => Promise<void>
+  getProfile: (accessToken: string) => Promise<void>
   logout: () => Promise<void>
 
   clearAuth: () => void
@@ -23,6 +26,29 @@ const useAuthStore = create<AuthStoreState>()(
 
       profile: null,
       setProfile: (profile) => set({ profile }),
+
+      refresh: async () => {
+        const refreshResponse = await instance.post<{ access: string }>(
+          "/accounts/me/refresh"
+        )
+        const { access } = refreshResponse.data
+        set({ accessToken: access })
+
+        const getProfile = get().getProfile
+        await getProfile(access)
+      },
+      getProfile: async (accessToken) => {
+        const response = await plainInstance.get<Profile>(
+          "/accounts/me/profile",
+          {
+            headers: { Authorization: `Bearer ${accessToken}` },
+            withCredentials: true,
+          }
+        )
+
+        const profile = response.data
+        set({ profile })
+      },
 
       logout: async () => {
         try {

--- a/src/shared/api/use-auth-store.ts
+++ b/src/shared/api/use-auth-store.ts
@@ -20,7 +20,7 @@ type AuthStoreState = {
 
 const useAuthStore = create<AuthStoreState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       accessToken: null,
       setAccessToken: (accessToken) => set({ accessToken }),
 


### PR DESCRIPTION
## 📌 작업 내용

- 소셜 로그인 후 refresh, getProfile로 정보를 받아온 후 스토어에 저장합니다

## 🔗 관련 이슈

- closes #293

## 📸 스크린샷 (선택)

- 현재 소셜 로그인을 하면 배포 서버로 리다이렉트가 되어서 배포 환경에서만 테스트할 수 있습니다

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
