### PR TITLE
fix: 아이폰환경 수정 및 리뷰카드 수정

### DIFF
--- a/src/features/_wide.index/page/5-customer-reviews/review-carousel/review-card-in-main/ReviewCardInMain.tsx
+++ b/src/features/_wide.index/page/5-customer-reviews/review-carousel/review-card-in-main/ReviewCardInMain.tsx
@@ -23,7 +23,8 @@ const ReviewCardInMain = ({ reviewInMain, index }: ReviewCardInMainProps) => {
         />
 
         <Vstack className="justify-between p-lg flex-1">
-          <p className="font-thin">{`"${review}"`}</p>
+          <p className="line-clamp-2 font-light">{`"${review}"`}</p>
+
           <Hstack className="w-full justify-start items-center">
             <p className="grow">{name}</p>
             <p className="text-sm text-text-sub">{created_at.slice(0, 10)}</p>

--- a/src/index.css
+++ b/src/index.css
@@ -433,3 +433,37 @@ body {
   opacity: 0;
   animation: shared-scent-label 0.6s ease-out 0.95s forwards;
 }
+
+input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  outline: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+
+  background: var(--color-primary);
+  border: none;
+  box-shadow: none;
+  outline: none;
+}
+
+input[type="range"]:focus {
+  outline: none;
+}
+
+input[type="range"]:focus-visible {
+  outline: none;
+}
+
+input[type="range"]::-webkit-slider-thumb:focus {
+  outline: none;
+}


### PR DESCRIPTION
## 📌 작업 내용

- iOS Chrome/WebKit 환경에서 슬라이더 thumb 주변 기본 스타일이 노출되는 문제를 수정했습니다.
- 슬라이더 thumb의 focus, tap highlight, 기본 appearance 스타일을 제거했습니다.
- 메인 리뷰 카드에서 리뷰 내용이 길어질 경우 카드 영역을 넘지 않도록 말줄임 처리를 적용했습니다.

## 🔗 관련 이슈

- closes #300

## 📸 스크린샷 (선택)
<img width="762" height="520" alt="image" src="https://github.com/user-attachments/assets/4013cec3-2da7-4bbb-b3f2-dd3a673a274c" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인