### PR TITLE
feat: 로그인 됐을 땐 login, signup 페이지 못 들어가게 수정 

### DIFF
--- a/src/routes/_narrow.tsx
+++ b/src/routes/_narrow.tsx
@@ -1,6 +1,16 @@
 import NarrowLayout from "@/features/_narrow/layout/NarrowLayout"
-import { createFileRoute } from "@tanstack/react-router"
+import useAuthStore from "@/shared/api/use-auth-store"
+import { createFileRoute, redirect } from "@tanstack/react-router"
 
 export const Route = createFileRoute("/_narrow")({
   component: NarrowLayout,
+  beforeLoad: () => {
+    const accessToken = useAuthStore.getState().accessToken
+    if (!accessToken) return
+
+    throw redirect({
+      to: "/",
+      replace: true,
+    })
+  },
 })


### PR DESCRIPTION
## 📌 작업 내용

- access 토큰이 존재할 땐 narrow 라우트에 접근하지 못하게 리다이렉트 합니다

## 🔗 관련 이슈

- closes #299

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
