### PR TITLE
fix: edit field에 타입 추가

### DIFF
--- a/src/features/my-page/pages/user-section/UserSection.tsx
+++ b/src/features/my-page/pages/user-section/UserSection.tsx
@@ -209,6 +209,8 @@ export const UserSection = ({ user, className }: UserSectionProps) => {
               value={form.birthday}
               onChange={handleChange("birthday")}
               icon={<CalendarDays size={18} strokeWidth={2} />}
+              type="date"
+              max={new Date().toISOString().split("T")[0]}
             />
           </>
         ) : (

--- a/src/features/my-page/pages/user-section/edit-field/EditField.tsx
+++ b/src/features/my-page/pages/user-section/edit-field/EditField.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react"
+import type { HTMLInputTypeAttribute, ReactNode } from "react"
 
 import { cn } from "@/lib/utils"
 import { Input } from "@/shared/components"
@@ -8,6 +8,8 @@ type EditFieldProps = {
   value: string
   onChange: (value: string) => void
   icon: ReactNode
+  type?: HTMLInputTypeAttribute
+  max?: string
 }
 
 export default function EditField({
@@ -15,6 +17,8 @@ export default function EditField({
   value,
   onChange,
   icon,
+  type = "text",
+  max,
 }: EditFieldProps) {
   return (
     <div
@@ -27,10 +31,12 @@ export default function EditField({
         {icon}
       </div>
 
-      <div className="flex flex-col justify-center">
+      <div className="flex flex-1 flex-col justify-center">
         <span className="text-sm leading-none text-text-sub">{label}</span>
         <Input
+          type={type}
           value={value}
+          max={max}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             onChange(e.target.value)
           }

--- a/src/features/my-page/pages/user-section/edit-field/EditField.tsx
+++ b/src/features/my-page/pages/user-section/edit-field/EditField.tsx
@@ -23,7 +23,7 @@ export default function EditField({
   return (
     <div
       className={cn(
-        "flex w-full items-center gap-3 rounded-lg border border-border-primary bg-card p-lg",
+        "flex w-full min-w-0 items-center gap-3 rounded-lg border border-border-primary bg-card p-lg",
         "shadow-md"
       )}
     >
@@ -31,12 +31,14 @@ export default function EditField({
         {icon}
       </div>
 
-      <div className="flex flex-1 flex-col justify-center">
+      <div className="flex min-w-0 flex-1 flex-col justify-center">
         <span className="text-sm leading-none text-text-sub">{label}</span>
+
         <Input
           type={type}
           value={value}
           max={max}
+          className="w-full min-w-0"
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             onChange(e.target.value)
           }


### PR DESCRIPTION
## 📌 작업 내용

-마이페이지 정보 수정에서, 양식에 맞지 않는 데이터 입력을 방지하기 위해 생년월일을 calendare date 타입으로 전달합니다.

## 🔗 관련 이슈

- closes #303 

## 📸 스크린샷 (선택)
<img width="633" height="382" alt="image" src="https://github.com/user-attachments/assets/82a8c203-c629-46bb-9af7-caf8b5b49dc0" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
