### PR TITLE
fix: 공유페이지 수정 및 로그아웃 수정

### DIFF
--- a/src/features/web-shared/page/WebSharedPage.tsx
+++ b/src/features/web-shared/page/WebSharedPage.tsx
@@ -24,9 +24,9 @@ const WebSharedPage = () => {
 
   const scent = data.recommended_scent
   return (
-    <main className="min-h-dvh overscroll-contain">
+    <main className="fixed inset-0 z-10 overflow-y-auto overscroll-contain">
       <Container>
-        <div className="flex min-h-dvh justify-center px-md py-lg pb-2xl">
+        <div className="flex min-h-dvh items-center justify-center px-md py-xl">
           <article className="fade-up w-full max-w-168 rounded-lg border border-border bg-white px-lg py-xl shadow-sm md:px-xl">
             <Vstack>
               <SharedHeader />

--- a/src/index.css
+++ b/src/index.css
@@ -433,37 +433,3 @@ body {
   opacity: 0;
   animation: shared-scent-label 0.6s ease-out 0.95s forwards;
 }
-
-input[type="range"] {
-  -webkit-appearance: none;
-  appearance: none;
-  background: transparent;
-  outline: none;
-  -webkit-tap-highlight-color: transparent;
-}
-
-input[type="range"]::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-
-  width: 32px;
-  height: 32px;
-  border-radius: 9999px;
-
-  background: var(--color-primary);
-  border: none;
-  box-shadow: none;
-  outline: none;
-}
-
-input[type="range"]:focus {
-  outline: none;
-}
-
-input[type="range"]:focus-visible {
-  outline: none;
-}
-
-input[type="range"]::-webkit-slider-thumb:focus {
-  outline: none;
-}

--- a/src/shared/api/axios-instance.ts
+++ b/src/shared/api/axios-instance.ts
@@ -40,7 +40,7 @@ instance.interceptors.response.use(
   async (error: AxiosError) => {
     const state = useAuthStore.getState()
     const setAccessToken = state.setAccessToken
-    const logout = state.logout
+    const clearAuthLogout = state.clearAuth
 
     if (!error.config) return Promise.reject(error)
 
@@ -59,7 +59,7 @@ instance.interceptors.response.use(
     } catch (error) {
       // NOTE: 재발급 실패 -> 추가 요청 없이 로그아웃
       console.log({ error })
-      logout()
+      clearAuthLogout()
       return Promise.reject(error)
     }
   }


### PR DESCRIPTION
## 📌 작업 내용

- 로그아웃 시 인증 상태 초기화 로직을 정리했습니다.
- `accessToken`뿐만 아니라 `profile` 상태도 함께 초기화되도록 수정했습니다.
- 로그아웃 후 다른 계정으로 로그인했을 때 이전 유저 정보가 잠깐 노출될 수 있는 문제를 방지했습니다.
- 인증 상태 초기화를 `clearAuth`로 분리해 재사용 가능하도록 정리했습니다.

## 🔗 관련 이슈

- closes #305 

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인