### PR TITLE
fix: 공유하기 주소 프로토콜 수정

### DIFF
--- a/src/features/keyword/page/ScentKeyword.tsx
+++ b/src/features/keyword/page/ScentKeyword.tsx
@@ -100,7 +100,7 @@ const ScentKeyword = () => {
   return (
     <Container className="relative px-10 pt-16 pb-20 md:px-30 md:pt-16 md:pb-40">
       {isPostKeywordResultPending && (
-        <div className="fixed inset-0 z-[99999] flex items-center justify-center bg-background/80 backdrop-blur-sm">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
           <LoadingState />
         </div>
       )}

--- a/src/features/result/page/sections/card-section/TopCardSection.tsx
+++ b/src/features/result/page/sections/card-section/TopCardSection.tsx
@@ -84,7 +84,9 @@ const TopCardSection = ({ result, type }: TopCardSectionProps) => {
       },
       {
         onSuccess: async ({ share_id }) => {
-          const webShareUrl = `fragmnt.pics/share-og/${share_id}`
+          const SHARE_OG_BASE_URL = "https://fragmnt.pics/share-og"
+
+          const webShareUrl = `${SHARE_OG_BASE_URL}/${share_id}`
           try {
             await navigator.clipboard.writeText(webShareUrl)
             showToast("공유 링크가 복사되었습니다")

--- a/src/features/survey/page/ScentSurvey.tsx
+++ b/src/features/survey/page/ScentSurvey.tsx
@@ -80,7 +80,7 @@ const ScentSurvey = () => {
   return (
     <Container className="relative px-10 pt-16 pb-20 md:px-30 md:pt-16 md:pb-40">
       {isSubmitting && (
-        <div className="absolute inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
           <LoadingState />
         </div>
       )}

--- a/src/shared/components/inputs/password-input/PasswordInput.tsx
+++ b/src/shared/components/inputs/password-input/PasswordInput.tsx
@@ -7,11 +7,17 @@ type EyeButtonProps = {
   isHidden: boolean
   setIsHidden: Dispatch<SetStateAction<boolean>>
 }
+
 const EyeButton = ({ isHidden, setIsHidden }: EyeButtonProps) => {
   const handleClick = () => setIsHidden((prev) => !prev)
-  const Icon = isHidden ? <EyeOff size={16} /> : <Eye size={16} />
+  const Icon = isHidden ? <Eye size={16} /> : <EyeOff size={16} />
+
   return (
-    <button type="button" onClick={handleClick}>
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label={isHidden ? "비밀번호 보기" : "비밀번호 숨기기"}
+    >
       {Icon}
     </button>
   )
@@ -20,11 +26,13 @@ const EyeButton = ({ isHidden, setIsHidden }: EyeButtonProps) => {
 type WithPasswordInputProps = {
   isError: boolean
 }
+
 const PasswordInput = ({
   isError,
   ...props
 }: Omit<InputProps, "type"> & WithPasswordInputProps) => {
   const [isHidden, setIsHidden] = useState(true)
+
   return (
     <Input
       {...props}


### PR DESCRIPTION
## 📌 작업 내용

- 모바일 환경에서 공유 링크 복사 시 정상 이동되도록 URL에 `https://` 프로토콜을 포함했습니다.
- 공유 링크 생성 경로를 배포 도메인 기준으로 정리했습니다.

## 🔗 관련 이슈

- closes #309 

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인