### PR TITLE
feat: 배포 오류 수정 및 demo 안내문구 추가

### DIFF
--- a/src/features/_wide.index/page/MainPage.tsx
+++ b/src/features/_wide.index/page/MainPage.tsx
@@ -28,17 +28,27 @@ const MainPage = () => {
     if (!accessToken) return
     navigate({ to: "/" })
   }, [socialLoginAccessToken, accessToken]) // eslint-disable-line react-hooks/exhaustive-deps
-
   return (
-    <Vstack gap="2xl" className="pb-2xl">
-      <Introduction />
-      <FindYourScent />
-      <ViewAllScents />
-      <img src={InsertionSrc} alt="삽입 이미지" />
-      <QuickStart />
-      <CustomerReviews />
-      <FAQ />
-    </Vstack>
+    <div className="relative">
+      <div className="absolute left-1/2 top-md z-10 w-[calc(100%-32px)] max-w-[520px] -translate-x-1/2 rounded-full border border-white/20 bg-white/20 px-sm py-xs text-center text-caption text-white/65 backdrop-blur-[2px]">
+        <strong className="font-medium text-white/75">Portfolio Demo</strong>
+        <span className="mx-xs text-white/45">·</span>
+        <span className="hidden sm:inline">
+          일부 기능은 목데이터 기반으로 동작합니다.
+        </span>
+        <span className="sm:hidden">목데이터 기반</span>
+      </div>
+
+      <Vstack gap="2xl" className="pb-2xl">
+        <Introduction />
+        <FindYourScent />
+        <ViewAllScents />
+        <img src={InsertionSrc} alt="삽입 이미지" />
+        <QuickStart />
+        <CustomerReviews />
+        <FAQ />
+      </Vstack>
+    </div>
   )
 }
 

--- a/src/features/_wide/layout/header/Header.tsx
+++ b/src/features/_wide/layout/header/Header.tsx
@@ -1,8 +1,18 @@
+import { Link } from "@tanstack/react-router"
+
 const Header = () => {
   return (
-    <div className="bg-card text-lg font-league-gothic font-bold w-full py-xs md:py-md flex justify-center  border-b border-border shadow-md">
-      fragmnt
-    </div>
+    <header className="w-full border-b border-border bg-card py-xs shadow-md md:py-md">
+      <div className="flex items-center justify-center px-md">
+        <Link
+          to="/"
+          className="font-league-gothic text-lg font-bold text-foreground"
+          aria-label="메인 페이지로 이동"
+        >
+          fragmnt
+        </Link>
+      </div>
+    </header>
   )
 }
 

--- a/src/features/chat/mocks/handlers.ts
+++ b/src/features/chat/mocks/handlers.ts
@@ -1,0 +1,264 @@
+import type { RecommendedScent } from "@/shared/types"
+import { delay, http, HttpResponse } from "msw"
+import type { CreateChatSessionResponse } from "../api/create-chat-session.api"
+import type {
+  ChatRecommendationResult,
+  ChatRecommendationResultResponse,
+  GetScentDetailResponse,
+  SendChatMessageResponse,
+} from "../types/message.types"
+import type { RetryChatRecommendationResponse } from "../types/retry-chat.types"
+
+type SendChatMessageRequest = {
+  message?: string
+}
+
+const mockChatScents = [
+  {
+    id: 1,
+    name: "우디 머스크",
+    eng_name: "Woody Musk",
+    description:
+      "차분한 우디 향과 부드러운 머스크가 어우러진 안정적인 분위기의 향입니다.",
+    tags: ["차분한", "우디", "머스크"],
+    thumbnail_url: "/msw-image/scent-woody-musk.jpg",
+  },
+  {
+    id: 2,
+    name: "시트러스 가든",
+    eng_name: "Citrus Garden",
+    description:
+      "상큼한 시트러스와 은은한 그린 노트가 어우러진 밝고 산뜻한 향입니다.",
+    tags: ["상큼한", "시트러스", "산뜻한"],
+    thumbnail_url: "/msw-image/scent-citrus-garden.jpg",
+  },
+  {
+    id: 3,
+    name: "플로럴 코튼",
+    eng_name: "Floral Cotton",
+    description:
+      "깨끗한 코튼 향에 은은한 플로럴 무드가 더해진 포근한 향입니다.",
+    tags: ["포근한", "플로럴", "코튼"],
+    thumbnail_url: "/msw-image/scent-floral-cotton.jpg",
+  },
+]
+
+const followUpReplies = [
+  "좋아요. 평소에는 산뜻한 향과 포근한 향 중 어느 쪽을 더 좋아하세요?",
+  "그럼 사용할 상황도 같이 보면 좋겠어요. 데일리용인가요, 특별한 날용인가요?",
+  "좋아요. 너무 달달한 향은 괜찮으세요, 아니면 피하고 싶으세요?",
+  "말씀해주신 느낌이면 방향이 잡히고 있어요. 조금 더 가벼운 쪽이 좋을까요?",
+]
+
+const recommendationComments = [
+  "말씀해주신 분위기라면 이 향이 잘 맞을 것 같아요.",
+  "이런 무드라면 저는 이 향을 먼저 추천드릴게요.",
+  "지금 이야기해주신 취향에는 이 향이 꽤 잘 어울려요.",
+  "너무 튀지 않으면서도 분위기 있는 향으로 골라봤어요.",
+]
+
+const retryComments = [
+  "좋아요. 이번엔 조금 다른 결로 골라봤어요.",
+  "이번에는 좀 더 부드러운 쪽으로 다시 추천드릴게요.",
+  "그럼 이번엔 부담이 덜한 향으로 바꿔볼게요.",
+  "좋아요. 이전 추천보다 조금 더 산뜻한 느낌으로 골라봤어요.",
+]
+
+const chatRecommendationResults = new Map<number, ChatRecommendationResult>()
+const chatMessageCountMap = new Map<number, number>()
+
+let sessionId = 1
+let recommendationId = 1
+let retryCount = 0
+
+const getRandomItem = <T>(items: T[]) => {
+  const randomIndex = Math.floor(Math.random() * items.length)
+
+  return items[randomIndex]
+}
+
+const getRandomScent = () => getRandomItem(mockChatScents)
+
+const createRecommendedScent = (
+  scent: (typeof mockChatScents)[number]
+): RecommendedScent =>
+  ({
+    id: scent.id,
+    name: scent.name,
+    eng_name: scent.eng_name,
+    description: scent.description,
+    tags: scent.tags,
+    thumbnail_url: scent.thumbnail_url,
+  }) as RecommendedScent
+
+const createChatRecommendationResult = ({
+  id,
+  scent,
+  aiComment,
+}: {
+  id: number
+  scent: (typeof mockChatScents)[number]
+  aiComment: string
+}): ChatRecommendationResult => ({
+  id,
+  recommended_scent: createRecommendedScent(scent),
+  ai_comment: aiComment,
+  match_score: 92,
+  source_type: "chatbot",
+  is_saved: false,
+  created_at: new Date().toISOString(),
+})
+
+export const chatbotHandlers = [
+  http.post("*/chatbot/sessions", async () => {
+    await delay(300)
+
+    const nextSessionId = sessionId++
+
+    chatMessageCountMap.set(nextSessionId, 0)
+
+    const response: CreateChatSessionResponse = {
+      status: "success",
+      data: {
+        id: nextSessionId,
+        status: "active",
+        created_at: new Date().toISOString(),
+      },
+    }
+
+    return HttpResponse.json(response)
+  }),
+
+  http.post(
+    "*/chatbot/sessions/:sessionId/messages",
+    async ({ request, params }) => {
+      await delay(700)
+
+      const currentSessionId = Number(params.sessionId)
+      const body = (await request.json()) as SendChatMessageRequest
+      const message = body.message ?? ""
+
+      const prevCount = chatMessageCountMap.get(currentSessionId) ?? 0
+      const nextCount = prevCount + 1
+
+      chatMessageCountMap.set(currentSessionId, nextCount)
+
+      const shouldRecommend =
+        nextCount >= 3 ||
+        message.includes("추천해줘") ||
+        message.includes("바로 추천")
+
+      if (!shouldRecommend) {
+        const response: SendChatMessageResponse = {
+          status: "success",
+          data: {
+            ai_comment: getRandomItem(followUpReplies),
+            is_recommendation: false,
+            recommendation_id: null,
+            scent_id: null,
+            source_type: "chat",
+          },
+        }
+
+        return HttpResponse.json(response)
+      }
+
+      const scent = getRandomScent()
+      const nextRecommendationId = recommendationId++
+      const aiComment = getRandomItem(recommendationComments)
+
+      const result = createChatRecommendationResult({
+        id: nextRecommendationId,
+        scent,
+        aiComment,
+      })
+
+      chatRecommendationResults.set(nextRecommendationId, result)
+
+      const response: SendChatMessageResponse = {
+        status: "success",
+        data: {
+          ai_comment: aiComment,
+          is_recommendation: true,
+          recommendation_id: nextRecommendationId,
+          scent_id: scent.id,
+          source_type: "chat",
+        },
+      }
+
+      return HttpResponse.json(response)
+    }
+  ),
+
+  http.post("*/chatbot/sessions/:sessionId/recommendations/retry", async () => {
+    await delay(900)
+
+    retryCount += 1
+
+    const scent = getRandomScent()
+    const nextRecommendationId = recommendationId++
+    const aiComment = getRandomItem(retryComments)
+
+    const result = createChatRecommendationResult({
+      id: nextRecommendationId,
+      scent,
+      aiComment,
+    })
+
+    chatRecommendationResults.set(nextRecommendationId, result)
+
+    const response: RetryChatRecommendationResponse = {
+      status: "success",
+      data: {
+        ai_comment: aiComment,
+        recommendation_id: nextRecommendationId,
+        scent_id: scent.id,
+        retry_count: retryCount,
+        source_type: "chatbot",
+      },
+    }
+
+    return HttpResponse.json(response)
+  }),
+
+  http.get("*/scents/:scentId", ({ params }) => {
+    const scentId = Number(params.scentId)
+    const scent = mockChatScents.find((item) => item.id === scentId)
+
+    if (!scent) {
+      return HttpResponse.json(
+        { message: "향기 정보를 찾을 수 없습니다." },
+        { status: 404 }
+      )
+    }
+
+    const response: GetScentDetailResponse = {
+      status: "success",
+      data: scent,
+    }
+
+    return HttpResponse.json(response)
+  }),
+
+  http.get(
+    "*/chatbot/sessions/:sessionId/recommendations/:recommendationId",
+    ({ params }) => {
+      const id = Number(params.recommendationId)
+      const result = chatRecommendationResults.get(id)
+
+      if (!result) {
+        return HttpResponse.json(
+          { message: "추천 결과를 찾을 수 없습니다." },
+          { status: 404 }
+        )
+      }
+
+      const response: ChatRecommendationResultResponse = {
+        status: "success",
+        data: result,
+      }
+
+      return HttpResponse.json(response)
+    }
+  ),
+]

--- a/src/features/chat/mocks/handlers.ts
+++ b/src/features/chat/mocks/handlers.ts
@@ -1,4 +1,5 @@
-import type { RecommendedScent } from "@/shared/types"
+import { baseAnalysisResultMockData } from "@/features/result/mock/result-base-mock"
+import { saveAnalysisResult } from "@/features/result/mock/result.store"
 import { delay, http, HttpResponse } from "msw"
 import type { CreateChatSessionResponse } from "../api/create-chat-session.api"
 import type {
@@ -12,36 +13,6 @@ import type { RetryChatRecommendationResponse } from "../types/retry-chat.types"
 type SendChatMessageRequest = {
   message?: string
 }
-
-const mockChatScents = [
-  {
-    id: 1,
-    name: "우디 머스크",
-    eng_name: "Woody Musk",
-    description:
-      "차분한 우디 향과 부드러운 머스크가 어우러진 안정적인 분위기의 향입니다.",
-    tags: ["차분한", "우디", "머스크"],
-    thumbnail_url: "/msw-image/scent-woody-musk.jpg",
-  },
-  {
-    id: 2,
-    name: "시트러스 가든",
-    eng_name: "Citrus Garden",
-    description:
-      "상큼한 시트러스와 은은한 그린 노트가 어우러진 밝고 산뜻한 향입니다.",
-    tags: ["상큼한", "시트러스", "산뜻한"],
-    thumbnail_url: "/msw-image/scent-citrus-garden.jpg",
-  },
-  {
-    id: 3,
-    name: "플로럴 코튼",
-    eng_name: "Floral Cotton",
-    description:
-      "깨끗한 코튼 향에 은은한 플로럴 무드가 더해진 포근한 향입니다.",
-    tags: ["포근한", "플로럴", "코튼"],
-    thumbnail_url: "/msw-image/scent-floral-cotton.jpg",
-  },
-]
 
 const followUpReplies = [
   "좋아요. 평소에는 산뜻한 향과 포근한 향 중 어느 쪽을 더 좋아하세요?",
@@ -66,6 +37,7 @@ const retryComments = [
 
 const chatRecommendationResults = new Map<number, ChatRecommendationResult>()
 const chatMessageCountMap = new Map<number, number>()
+const chatLastUserMessageMap = new Map<number, string>()
 
 let sessionId = 1
 let recommendationId = 1
@@ -77,35 +49,24 @@ const getRandomItem = <T>(items: T[]) => {
   return items[randomIndex]
 }
 
-const getRandomScent = () => getRandomItem(mockChatScents)
-
-const createRecommendedScent = (
-  scent: (typeof mockChatScents)[number]
-): RecommendedScent =>
-  ({
-    id: scent.id,
-    name: scent.name,
-    eng_name: scent.eng_name,
-    description: scent.description,
-    tags: scent.tags,
-    thumbnail_url: scent.thumbnail_url,
-  }) as RecommendedScent
-
 const createChatRecommendationResult = ({
   id,
-  scent,
   aiComment,
+  userMessage,
 }: {
   id: number
-  scent: (typeof mockChatScents)[number]
   aiComment: string
+  userMessage: string
 }): ChatRecommendationResult => ({
   id,
-  recommended_scent: createRecommendedScent(scent),
+  type: "chatbot",
+  recommended_scent: baseAnalysisResultMockData.recommended_scent,
   ai_comment: aiComment,
-  match_score: 92,
+  match_score: baseAnalysisResultMockData.match_score,
   source_type: "chatbot",
-  is_saved: false,
+  user_message: userMessage,
+  ai_keywords: ["대화", "취향", "추천"],
+  is_saved: baseAnalysisResultMockData.is_saved,
   created_at: new Date().toISOString(),
 })
 
@@ -142,6 +103,7 @@ export const chatbotHandlers = [
       const nextCount = prevCount + 1
 
       chatMessageCountMap.set(currentSessionId, nextCount)
+      chatLastUserMessageMap.set(currentSessionId, message)
 
       const shouldRecommend =
         nextCount >= 3 ||
@@ -163,17 +125,17 @@ export const chatbotHandlers = [
         return HttpResponse.json(response)
       }
 
-      const scent = getRandomScent()
       const nextRecommendationId = recommendationId++
       const aiComment = getRandomItem(recommendationComments)
 
       const result = createChatRecommendationResult({
         id: nextRecommendationId,
-        scent,
         aiComment,
+        userMessage: message,
       })
 
       chatRecommendationResults.set(nextRecommendationId, result)
+      saveAnalysisResult(result)
 
       const response: SendChatMessageResponse = {
         status: "success",
@@ -181,7 +143,7 @@ export const chatbotHandlers = [
           ai_comment: aiComment,
           is_recommendation: true,
           recommendation_id: nextRecommendationId,
-          scent_id: scent.id,
+          scent_id: baseAnalysisResultMockData.recommended_scent.id,
           source_type: "chat",
         },
       }
@@ -190,42 +152,47 @@ export const chatbotHandlers = [
     }
   ),
 
-  http.post("*/chatbot/sessions/:sessionId/recommendations/retry", async () => {
-    await delay(900)
+  http.post(
+    "*/chatbot/sessions/:sessionId/recommendations/retry",
+    async ({ params }) => {
+      await delay(900)
 
-    retryCount += 1
+      const currentSessionId = Number(params.sessionId)
+      retryCount += 1
 
-    const scent = getRandomScent()
-    const nextRecommendationId = recommendationId++
-    const aiComment = getRandomItem(retryComments)
+      const nextRecommendationId = recommendationId++
+      const aiComment = getRandomItem(retryComments)
+      const userMessage = chatLastUserMessageMap.get(currentSessionId) ?? ""
 
-    const result = createChatRecommendationResult({
-      id: nextRecommendationId,
-      scent,
-      aiComment,
-    })
+      const result = createChatRecommendationResult({
+        id: nextRecommendationId,
+        aiComment,
+        userMessage,
+      })
 
-    chatRecommendationResults.set(nextRecommendationId, result)
+      chatRecommendationResults.set(nextRecommendationId, result)
+      saveAnalysisResult(result)
 
-    const response: RetryChatRecommendationResponse = {
-      status: "success",
-      data: {
-        ai_comment: aiComment,
-        recommendation_id: nextRecommendationId,
-        scent_id: scent.id,
-        retry_count: retryCount,
-        source_type: "chatbot",
-      },
+      const response: RetryChatRecommendationResponse = {
+        status: "success",
+        data: {
+          ai_comment: aiComment,
+          recommendation_id: nextRecommendationId,
+          scent_id: baseAnalysisResultMockData.recommended_scent.id,
+          retry_count: retryCount,
+          source_type: "chatbot",
+        },
+      }
+
+      return HttpResponse.json(response)
     }
-
-    return HttpResponse.json(response)
-  }),
+  ),
 
   http.get("*/scents/:scentId", ({ params }) => {
     const scentId = Number(params.scentId)
-    const scent = mockChatScents.find((item) => item.id === scentId)
+    const scent = baseAnalysisResultMockData.recommended_scent
 
-    if (!scent) {
+    if (scent.id !== scentId) {
       return HttpResponse.json(
         { message: "향기 정보를 찾을 수 없습니다." },
         { status: 404 }
@@ -234,7 +201,14 @@ export const chatbotHandlers = [
 
     const response: GetScentDetailResponse = {
       status: "success",
-      data: scent,
+      data: {
+        id: scent.id,
+        name: scent.name,
+        eng_name: scent.eng_name,
+        description: scent.description,
+        tags: scent.tags,
+        thumbnail_url: scent.thumbnail_url,
+      },
     }
 
     return HttpResponse.json(response)

--- a/src/features/chat/types/message.types.ts
+++ b/src/features/chat/types/message.types.ts
@@ -1,4 +1,4 @@
-import type { RecommendedScent } from "@/shared/types"
+import type { ChatbotAnalysisResult } from "@/shared/types"
 
 export type MessageRole = "user" | "assistant"
 
@@ -72,12 +72,4 @@ export type ChatRecommendationResultResponse = {
   data: ChatRecommendationResult
 }
 
-export type ChatRecommendationResult = {
-  id: number
-  recommended_scent: RecommendedScent
-  ai_comment: string
-  match_score: number
-  source_type: "chatbot"
-  is_saved: boolean
-  created_at: string
-}
+export type ChatRecommendationResult = ChatbotAnalysisResult

--- a/src/features/my-page/mocks/handlers.ts
+++ b/src/features/my-page/mocks/handlers.ts
@@ -1,6 +1,7 @@
 import { delay, http, HttpResponse } from "msw"
 
 import { createAnalysisResultMock } from "@/features/result/mock/result-factory"
+import { getAnalysisResult } from "@/features/result/mock/result.store"
 import { mockFavoriteScents } from "./favoriteScents.mock"
 import { mockHistoryList } from "./history.mock"
 import { mockUserProfile } from "./myPage.mock"
@@ -123,27 +124,38 @@ export const myPageHandlers = [
     })
   }),
 
-  http.get(`${BASE_URL}/analyses/history/:historyId`, ({ params, request }) => {
-    const { historyId } = params as { historyId: string }
+  http.get(`${BASE_URL}/analyses/:analysisId`, ({ params }) => {
+    const { analysisId } = params as { analysisId: string }
+    const numericAnalysisId = Number(analysisId)
 
-    const url = new URL(request.url)
-    const type = url.searchParams.get("type") ?? "image"
+    if (Number.isNaN(numericAnalysisId)) {
+      return HttpResponse.json(
+        { message: "잘못된 추천 결과 ID입니다." },
+        { status: 400 }
+      )
+    }
+
+    const storedResult = getAnalysisResult(numericAnalysisId)
+
+    if (storedResult) {
+      return HttpResponse.json(storedResult)
+    }
 
     const historyItem = mockHistoryList.find(
-      (item) => item.id === Number(historyId)
+      (history) => history.id === numericAnalysisId
     )
 
     if (!historyItem) {
       return HttpResponse.json(
-        { message: "추천 기록을 찾을 수 없습니다." },
+        { message: "추천 결과를 찾을 수 없습니다." },
         { status: 404 }
       )
     }
 
     return HttpResponse.json(
       createAnalysisResultMock({
-        id: Number(historyId),
-        type: type === "keyword" ? "keyword" : "image",
+        id: numericAnalysisId,
+        type: historyItem.type,
       })
     )
   }),

--- a/src/features/my-page/mocks/history.mock.ts
+++ b/src/features/my-page/mocks/history.mock.ts
@@ -1,6 +1,8 @@
+import type { ResultType } from "@/shared/types"
+
 export type HistoryItem = {
   id: number
-  type: "image"
+  type: ResultType
   recommended_scent: {
     id: number
     name: string

--- a/src/features/result/mock/handlers.ts
+++ b/src/features/result/mock/handlers.ts
@@ -1,19 +1,56 @@
 import { mockHistoryList } from "@/features/my-page/mocks/history.mock"
-import type { ResultType } from "@/shared/types"
+import type { AnalysisResult, ResultType } from "@/shared/types"
 import { delay, http, HttpResponse } from "msw"
-import { analysisResultStore } from "./result.store"
+import { createAnalysisResultMock } from "./result-factory"
+import { getAnalysisResult, saveAnalysisResult } from "./result.store"
 
 type SaveAnalysisFeedbackRequest = {
   status?: boolean
 }
+
 type PostWebShareRequest = {
   result_id?: number
   type?: ResultType
 }
+
 const getHistoryResult = (resultId: number, type: ResultType) => {
   return mockHistoryList.find(
     (item) => item.id === resultId && item.type === type
   )
+}
+
+const createFallbackResult = ({
+  id,
+  type,
+}: {
+  id: number
+  type: ResultType
+}): AnalysisResult => {
+  switch (type) {
+    case "image":
+      return createAnalysisResultMock({
+        id,
+        type: "image",
+      })
+
+    case "chatbot":
+      return createAnalysisResultMock({
+        id,
+        type: "chatbot",
+      })
+
+    case "keyword":
+      return createAnalysisResultMock({
+        id,
+        type: "keyword",
+      })
+
+    case "survey":
+      return createAnalysisResultMock({
+        id,
+        type: "survey",
+      })
+  }
 }
 
 export const resultHandlers = [
@@ -30,7 +67,7 @@ export const resultHandlers = [
       )
     }
 
-    const storedResult = analysisResultStore.get(resultId)
+    const storedResult = getAnalysisResult(resultId)
 
     if (storedResult && storedResult.type === type) {
       return HttpResponse.json(storedResult)
@@ -38,14 +75,18 @@ export const resultHandlers = [
 
     const historyResult = getHistoryResult(resultId, type)
 
-    if (!historyResult) {
-      return HttpResponse.json(
-        { message: "분석 결과를 찾을 수 없습니다." },
-        { status: 404 }
-      )
+    if (historyResult) {
+      return HttpResponse.json(historyResult)
     }
 
-    return HttpResponse.json(historyResult)
+    const fallbackResult = createFallbackResult({
+      id: resultId,
+      type,
+    })
+
+    saveAnalysisResult(fallbackResult)
+
+    return HttpResponse.json(fallbackResult)
   }),
 
   http.patch("*/analyses/feedback/:resultId", async ({ params, request }) => {
@@ -72,10 +113,10 @@ export const resultHandlers = [
       )
     }
 
-    const storedResult = analysisResultStore.get(resultId)
+    const storedResult = getAnalysisResult(resultId)
 
     if (storedResult && storedResult.type === type) {
-      analysisResultStore.set(resultId, {
+      saveAnalysisResult({
         ...storedResult,
         is_saved: body.status,
       })
@@ -105,7 +146,7 @@ export const resultHandlers = [
 
     return HttpResponse.json({
       share_id: shareId,
-      og_crawler: `https://fragmnt-space.vercel.app/share-og/${shareId}`,
+      og_crawler: `https://fragmnt-space.vercel.app/share/${shareId}`,
     })
   }),
 ]

--- a/src/features/result/mock/handlers.ts
+++ b/src/features/result/mock/handlers.ts
@@ -73,9 +73,16 @@ export const resultHandlers = [
       return HttpResponse.json(storedResult)
     }
 
-    const historyResult = getHistoryResult(resultId, type)
+    const historyItem = getHistoryResult(resultId, type)
 
-    if (historyResult) {
+    if (historyItem) {
+      const historyResult = createFallbackResult({
+        id: resultId,
+        type: historyItem.type,
+      })
+
+      saveAnalysisResult(historyResult)
+
       return HttpResponse.json(historyResult)
     }
 

--- a/src/features/result/page/sections/ai-section/AISection.tsx
+++ b/src/features/result/page/sections/ai-section/AISection.tsx
@@ -8,31 +8,42 @@ import SurveyAIContent from "./survey-ai-content/SurveyAIContent"
 type AISectionProps = {
   result: AnalysisResult
 }
+const hasArrayContent = (value?: unknown) => {
+  return Array.isArray(value) && value.length > 0
+}
+
+const hasTextContent = (value?: unknown) => {
+  return typeof value === "string" && value.trim().length > 0
+}
+
 const hasAIContent = (result: AnalysisResult) => {
   switch (result.type) {
     case "image":
-      return Boolean(
-        result.ai_comment ||
-        result.presigned_image_url ||
-        result.ai_tags.length > 0 ||
-        result.ai_keywords.length > 0
+      return (
+        hasTextContent(result.ai_comment) ||
+        hasTextContent(result.presigned_image_url) ||
+        hasArrayContent(result.ai_tags) ||
+        hasArrayContent(result.ai_keywords)
       )
 
     case "keyword":
     case "survey":
-      return Boolean(result.ai_comment || result.user_input.length > 0)
+      return (
+        hasTextContent(result.ai_comment) || hasArrayContent(result.user_input)
+      )
 
     case "chatbot":
-      return Boolean(
-        result.ai_comment ||
-        result.user_message ||
-        result.ai_keywords.length > 0
+      return (
+        hasTextContent(result.ai_comment) ||
+        hasTextContent(result.user_message) ||
+        hasArrayContent(result.ai_keywords)
       )
 
     default:
       return false
   }
 }
+
 const AISection = ({ result }: AISectionProps) => {
   if (!hasAIContent(result)) {
     return <AIEmptyCard></AIEmptyCard>

--- a/src/features/result/page/sections/ai-section/chatbot-ai-content/ChatbotAISection.tsx
+++ b/src/features/result/page/sections/ai-section/chatbot-ai-content/ChatbotAISection.tsx
@@ -10,7 +10,10 @@ const ChatbotAIContent = ({ result }: ChatbotAIContentProps) => {
   const { ai_comment, user_message, ai_keywords } = result
 
   const keywords = Array.isArray(ai_keywords) ? ai_keywords : []
-  const userMessages = Array.isArray(user_message) ? user_message : []
+  const userMessages =
+    typeof user_message === "string" && user_message.trim().length > 0
+      ? [user_message]
+      : []
   const hasUserMessage = userMessages.length > 0
 
   return (

--- a/src/features/result/page/sections/scent-section/ScentSection.tsx
+++ b/src/features/result/page/sections/scent-section/ScentSection.tsx
@@ -15,46 +15,52 @@ const ScentSection = ({ scent }: ScentSectionProps) => {
     return null
   }
 
-  const notes = scent.scent_notes
-  const profile = scent.profile
+  const items = scent.profile ? getProfileItems(scent.profile) : []
+  const noteList = scent.scent_notes ? getNoteList(scent.scent_notes) : []
 
-  const items = getProfileItems(profile)
-  const noteList = getNoteList(notes)
+  const hasProfile = items.length > 0
+  const hasNotes = noteList.length > 0
+
+  if (!hasProfile && !hasNotes) {
+    return null
+  }
 
   return (
-    <div className="w-full mt-md">
-      <div className="flex flex-col md:flex-row gap-sm w-full">
-        {/* profile */}
-        <div className="flex-1 w-full rounded-lg border border-border bg-white p-xl">
-          <div className="mb-md text-sm font-semibold text-text-primary">
-            SCENT PROFILE
-          </div>
+    <div className="mt-md w-full">
+      <div className="flex w-full flex-col gap-sm md:flex-row">
+        {hasProfile && (
+          <div className="w-full flex-1 rounded-lg border border-border bg-white p-xl">
+            <div className="mb-md text-sm font-semibold text-text-primary">
+              SCENT PROFILE
+            </div>
 
-          <div className="mt-md flex flex-col gap-md">
-            {items.map((item) => (
-              <StateBar
-                key={item.label}
-                label={item.label}
-                value={item.value}
-                leftText={item.leftText}
-                rightText={item.rightText}
-              />
-            ))}
+            <div className="mt-md flex flex-col gap-md">
+              {items.map((item) => (
+                <StateBar
+                  key={item.label}
+                  label={item.label}
+                  value={item.value}
+                  leftText={item.leftText}
+                  rightText={item.rightText}
+                />
+              ))}
+            </div>
           </div>
-        </div>
+        )}
 
-        {/* notes */}
-        <div className="flex-1 w-full rounded-lg border border-border bg-white p-xl">
-          <div className="mb-md text-sm font-semibold text-text-primary">
-            NOTE COMPOSITION
-          </div>
+        {hasNotes && (
+          <div className="w-full flex-1 rounded-lg border border-border bg-white p-xl">
+            <div className="mb-md text-sm font-semibold text-text-primary">
+              NOTE COMPOSITION
+            </div>
 
-          <div className="mt-sm flex flex-col gap-md">
-            {noteList.map((note) => (
-              <NoteSectionCard key={note.labelEn} {...note} size="md" />
-            ))}
+            <div className="mt-sm flex flex-col gap-md">
+              {noteList.map((note) => (
+                <NoteSectionCard key={note.labelEn} {...note} size="md" />
+              ))}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   )

--- a/src/shared/mocks/handlers.ts
+++ b/src/shared/mocks/handlers.ts
@@ -2,6 +2,7 @@ import { findEmailHandlers } from "@/features/_narrow.find-email/mocks/handlers"
 import { findPasswordHandlers } from "@/features/_narrow.find-password/mocks/handlers"
 import { authHandlers } from "@/features/_narrow.login/mocks/handlers"
 import { mainPageHandlers } from "@/features/_wide.index/mocks/main-page-handler"
+import { chatbotHandlers } from "@/features/chat/mocks/handlers"
 import { keywordHandlers } from "@/features/keyword/mocks/handlers"
 import { myPageHandlers } from "@/features/my-page/mocks/handlers"
 import { photoHandlers } from "@/features/photo/mocks/handlers"
@@ -25,7 +26,7 @@ export const handlers = [
   ...keywordHandlers,
   ...authHandlers,
   ...photoHandlers,
-
+  ...chatbotHandlers,
   ...findEmailHandlers,
   ...findPasswordHandlers,
   ...webSharedHandlers,

--- a/src/shared/mocks/handlers.ts
+++ b/src/shared/mocks/handlers.ts
@@ -16,7 +16,7 @@ export const handlers = [
   http.get("/api/hello", () => {
     return HttpResponse.json({ message: "Hello, world!", code: 200 })
   }),
-
+  ...resultHandlers,
   ...myPageHandlers,
   ...scentHandlers,
   ...detailPageHandlers,
@@ -25,7 +25,7 @@ export const handlers = [
   ...keywordHandlers,
   ...authHandlers,
   ...photoHandlers,
-  ...resultHandlers,
+
   ...findEmailHandlers,
   ...findPasswordHandlers,
   ...webSharedHandlers,


### PR DESCRIPTION
## 📌 작업 내용

- MSW 기반 포트폴리오 데모 환경 안내 문구 추가
- 메인 페이지 상단에 `Portfolio Demo` 안내 배지 표시
- 데모 안내가 메인 히어로 영역을 방해하지 않도록 투명도와 톤 조정
- 헤더 로고 클릭 시 메인 페이지(`/`)로 이동하도록 수정
- 헤더 내 팝오버 방식 대신, 레이아웃 충돌이 적은 메인 안내 방식으로 변경

## 🔗 관련 이슈

- closes #315 

## 📸 스크린샷 (선택)

- 메인 상단 Portfolio Demo 안내 표시

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인