### PR TITLE
feat: 고객후기 스켈레톤 ui 추가 

### DIFF
--- a/src/features/_wide.index/page/5-customer-reviews/CustomerReviewsSkeleton.tsx
+++ b/src/features/_wide.index/page/5-customer-reviews/CustomerReviewsSkeleton.tsx
@@ -1,0 +1,16 @@
+import SectionVstack from "../section-container/SectionContainer"
+import ReviewCarouselSkeleton from "./ReviewCarouselSkeleton"
+
+const CustomerReviewsSkeleton = () => {
+  return (
+    <SectionVstack>
+      <div
+        aria-hidden="true"
+        className="h-[24px] w-[120px] animate-pulse rounded-sm bg-gray-10"
+      />
+      <ReviewCarouselSkeleton />
+    </SectionVstack>
+  )
+}
+
+export default CustomerReviewsSkeleton

--- a/src/features/_wide.index/page/5-customer-reviews/ReviewCarouselSkeleton.tsx
+++ b/src/features/_wide.index/page/5-customer-reviews/ReviewCarouselSkeleton.tsx
@@ -1,0 +1,56 @@
+import { Hstack, RoundBox, Vstack } from "@/shared/components"
+import clsx from "clsx"
+import styles from "./review-carousel/ReviewCarousel.module.css"
+
+const SkeletonBlock = ({ className }: { className: string }) => {
+  return (
+    <div
+      aria-hidden="true"
+      className={`animate-pulse rounded-sm bg-gray-10 ${className}`}
+    />
+  )
+}
+
+const ReviewCardSkeleton = () => {
+  return (
+    <RoundBox
+      padding="none"
+      className="h-90 w-60 shrink-0 overflow-hidden bg-card shadow-box"
+    >
+      <Vstack gap="none" className="h-full">
+        <SkeletonBlock className="aspect-square w-full rounded-none" />
+
+        <Vstack className="flex-1 justify-between p-lg">
+          <Vstack gap="sm">
+            <SkeletonBlock className="h-[23px] w-full" />
+            <SkeletonBlock className="h-[23px] w-3/4" />
+          </Vstack>
+
+          <Hstack className="w-full items-center justify-start">
+            <SkeletonBlock className="h-[23px] w-[64px]" />
+            <SkeletonBlock className="ml-auto h-[18px] w-[76px]" />
+          </Hstack>
+        </Vstack>
+      </Vstack>
+    </RoundBox>
+  )
+}
+
+const ReviewCarouselSkeleton = () => {
+  return (
+    <div className="relative">
+      <Hstack
+        className={clsx(
+          "justify-start overflow-x-hidden pb-sm -mx-2xl px-2xl",
+          styles.review_carousel_mask
+        )}
+      >
+        {Array.from({ length: 4 }).map((_, index) => (
+          <ReviewCardSkeleton key={index} />
+        ))}
+      </Hstack>
+    </div>
+  )
+}
+
+export default ReviewCarouselSkeleton

--- a/src/features/_wide.index/page/5-customer-reviews/review-carousel/ReviewCarousel.tsx
+++ b/src/features/_wide.index/page/5-customer-reviews/review-carousel/ReviewCarousel.tsx
@@ -7,6 +7,7 @@ import { useQuery } from "@tanstack/react-query"
 import clsx from "clsx"
 import { ChevronLeft, ChevronRight } from "lucide-react"
 import { useState } from "react"
+import ReviewCarouselSkeleton from "../ReviewCarouselSkeleton"
 import ReviewCardInMain from "./review-card-in-main/ReviewCardInMain"
 import styles from "./ReviewCarousel.module.css"
 
@@ -24,7 +25,7 @@ const ReviewCarousel = () => {
   } = useQuery(makeReviewsInMainQueryOptions())
 
   if (isLoading) {
-    return null
+    return <ReviewCarouselSkeleton />
   }
 
   if (error) {

--- a/src/features/_wide.index/page/MainPage.tsx
+++ b/src/features/_wide.index/page/MainPage.tsx
@@ -10,6 +10,7 @@ import Introduction from "./1-introduction/Introduction"
 import FindYourScent from "./2-find-your-scent/FindYourScent"
 import ViewAllScents from "./3-view-all-scents/ViewAllScents"
 import QuickStart from "./4-quick-start/QuickStart"
+import CustomerReviewsSkeleton from "./5-customer-reviews/CustomerReviewsSkeleton"
 
 const CustomerReviews = lazy(
   () => import("./5-customer-reviews/CustomerReviews")
@@ -66,8 +67,8 @@ const MainPage = () => {
 
         <QuickStart />
 
-        <LazyOnView rootMargin="300px">
-          <Suspense fallback={null}>
+        <LazyOnView rootMargin="300px" fallback={<CustomerReviewsSkeleton />}>
+          <Suspense fallback={<CustomerReviewsSkeleton />}>
             <CustomerReviews />
           </Suspense>
         </LazyOnView>


### PR DESCRIPTION
## 📌 작업 내용

- 고객후기 섹션의 lazy loading 과정에서 콘텐츠가 갑자기 나타나는 느낌을 줄이기 위해 `CustomerReviewsSkeleton`을 추가했습니다.
- `CustomerReviews`의 `LazyOnView fallback`과 `Suspense fallback`에 동일한 Skeleton UI를 적용했습니다.
- 후기 카드 영역에는 `ReviewCarouselSkeleton`을 추가해 실제 후기 카드와 유사한 크기의 placeholder가 렌더링되도록 했습니다.
- 후기 API 로딩 상태에서 `null` 대신 `ReviewCarouselSkeleton`을 렌더링하도록 수정했습니다.
- FAQ 섹션은 Skeleton 적용 대상이 아니므로 기존처럼 fallback을 `null`로 유지했습니다.
- 기존 `React.lazy`, `Suspense`, `LazyOnView` 기반 지연 로딩 구조는 유지했습니다.

## 🔗 관련 이슈

- closes #323

## 📸 스크린샷 (선택)

## ✅ 검증

- `node_modules\.bin\tsc.cmd -b` 통과
- `node_modules\.bin\vite.CMD build` 통과

## ✅ 체크리스트

- [x] 코드 컨벤션 확인
- [x] lint 에러 없음
- [x] 빌드 정상 확인